### PR TITLE
Fixing timetable conversion to and from dictionary

### DIFF
--- a/mrs/structs/timetable.py
+++ b/mrs/structs/timetable.py
@@ -105,9 +105,9 @@ class Timetable(object):
     def to_dict(self):
         timetable_dict = dict()
         timetable_dict['robot_id'] = self.robot_id
-        timetable_dict['stn'] = self.stn.to_json()
-        timetable_dict['dispatchable_graph'] = self.dispatchable_graph.to_json()
-        timetable_dict['schedule'] = self.schedule.to_json()
+        timetable_dict['stn'] = self.stn.to_dict()
+        timetable_dict['dispatchable_graph'] = self.dispatchable_graph.to_dict()
+        timetable_dict['schedule'] = self.schedule.to_dict()
 
         return timetable_dict
 
@@ -117,9 +117,9 @@ class Timetable(object):
         timetable = Timetable(stp, robot_id)
         stn_cls = stp.get_stn()
 
-        timetable.stn = stn_cls.from_json(timetable_dict['stn'])
-        timetable.dispatchable_graph = stn_cls.from_json(timetable_dict['dispatchable_graph'])
-        timetable.schedule = stn_cls.from_json(timetable_dict['schedule'])
+        timetable.stn = stn_cls.from_dict(timetable_dict['stn'])
+        timetable.dispatchable_graph = stn_cls.from_dict(timetable_dict['dispatchable_graph'])
+        timetable.schedule = stn_cls.from_dict(timetable_dict['schedule'])
 
         return timetable
 

--- a/tests/data/non_overlapping_2.yaml
+++ b/tests/data/non_overlapping_2.yaml
@@ -1,0 +1,68 @@
+dataset_name: non_overlapping_1
+dataset_type: non_overlapping_tw
+interval_type: random
+lower_bound: 60
+task_type: generic_task
+start_time: 1566298588.7963254
+tasks:
+  002767db-01f3-4e0c-af4e-52c4d81bd713:
+    earliest_start_time: 1566298836.25
+    estimated_duration: 9.12
+    finish_pose_name: second_door_outside
+    hard_constraints: true
+    id: 002767db-01f3-4e0c-af4e-52c4d81bd713
+    latest_start_time: 1566298923.46
+    start_pose_name: table
+    status:
+      status: 1
+      task_id: 002767db-01f3-4e0c-af4e-52c4d81bd713
+      delayed: false
+  173d27eb-d0a4-4b94-986b-1e9b8eca0579:
+    earliest_start_time: 1566301785.87
+    estimated_duration: 6.84
+    finish_pose_name: second_door_outside
+    hard_constraints: true
+    id: 173d27eb-d0a4-4b94-986b-1e9b8eca0579
+    latest_start_time: 1566301947.89
+    start_pose_name: inspection_area
+    status:
+      status: 1
+      task_id: 173d27eb-d0a4-4b94-986b-1e9b8eca0579
+      delayed: false
+  4076f78b-16d8-4057-a1ad-d16d239764fa:
+    earliest_start_time: 1566299068.12
+    estimated_duration: 2.74
+    finish_pose_name: shelf
+    hard_constraints: true
+    id: 4076f78b-16d8-4057-a1ad-d16d239764fa
+    latest_start_time: 1566299230.80
+    start_pose_name: cupboard
+    status:
+      status: 1
+      task_id: 002767db-01f3-4e0c-af4e-52c4d81bd713
+      delayed: false
+  6d17963b-10b5-4143-b279-84d8e93aaaa3:
+    earliest_start_time: 1566302231.67
+    estimated_duration: 2.3
+    finish_pose_name: observation_pose
+    hard_constraints: true
+    id: 6d17963b-10b5-4143-b279-84d8e93aaaa3
+    latest_start_time: 1566302526.59
+    start_pose_name: living_room
+    status:
+      status: 1
+      task_id: 6d17963b-10b5-4143-b279-84d8e93aaaa3
+      delayed: false
+  73ace543-260e-474a-9112-3abd470ed5b5:
+    earliest_start_time: 1566301092.70
+    estimated_duration: 8.24
+    finish_pose_name: kitchen
+    hard_constraints: true
+    id: 73ace543-260e-474a-9112-3abd470ed5b5
+    latest_start_time: 1566301365.23
+    start_pose_name: shelf
+    status:
+      status: 1
+      task_id: 73ace543-260e-474a-9112-3abd470ed5b5
+      delayed: false
+upper_bound: 300


### PR DESCRIPTION
Fixing timetable struct to dictionary conversion to improve its visualization in the mongo db.
- Before, to_dict was converting the object to a json string, now it converts it to a dictionary. 
- Before, from_dict was receiving a json string, now it receives a dictionary

Needs: https://github.com/ropod-project/mrta_stn/pull/3