### PR TITLE
Changing Timetable initialization

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,11 +5,12 @@ ccu_store:
 robot_store:
   db_name: ropod_store
   port: 27017
-resources:
-  fleet:
-    - ropod_001
-    - ropod_002
-    - ropod_003
+resource_manager:
+  resources:
+    fleet:
+      - ropod_001
+      - ropod_002
+      - ropod_003
 
 plugins:
   task_allocation:
@@ -21,7 +22,7 @@ plugins:
     robot_proxies: true
     stp_solver: srea
   auctioneer:
-    round_time: 15 # seconds
+    round_time: 5 # seconds
     alternative_timeslots: True
   dispatcher:
     freeze_window: 300 # seconds

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -49,8 +49,6 @@ robot_proxy:
         message_types: # Types of messages the node will listen to. Messages not listed will be ignored
           - TASK-ANNOUNCEMENT
           - ALLOCATION
-          - TIMETABLE
-          - DELETE-TASK
         debug_msgs: false
       acknowledge: false
       publish:
@@ -71,10 +69,6 @@ robot_proxy:
           component: 'bidder.task_announcement_cb'
         - msg_type: 'ALLOCATION'
           component: 'bidder.allocation_cb'
-        - msg_type: 'TIMETABLE'
-          component: '.timetable_cb'
-        - msg_type: 'DELETE-TASK'
-          component: '.delete_task_cb'
 
 api:
   version: 0.1.0

--- a/mrs/db_interface.py
+++ b/mrs/db_interface.py
@@ -78,10 +78,15 @@ class DBInterface(object):
 
     def get_timetable(self, robot_id, stp):
         collection = self.store.db['timetables']
+
         timetable_dict = collection.find_one({'robot_id': robot_id})
 
         if timetable_dict is None:
-            return
-        timetable = Timetable.from_dict(timetable_dict, stp)
+            timetable = Timetable(robot_id, stp)
+        else:
+            timetable = Timetable.from_dict(timetable_dict, stp)
         return timetable
+
+    def clean(self):
+        self.store.client.drop_database(self.store.db_name)
 

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -49,10 +49,10 @@ class Robot(RobotBase):
 
 if __name__ == '__main__':
 
-    from fleet_management.config.loader import Config
+    from fleet_management.config.loader import Configurator
 
     config_file_path = '../config/config.yaml'
-    config = Config(config_file_path, initialize=False)
+    config = Configurator(config_file_path, initialize=False)
     config.configure_logger()
 
     parser = argparse.ArgumentParser()

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -21,20 +21,6 @@ class Robot(RobotBase):
         self.logger = logging.getLogger('mrs.robot.%s' % self.id)
         self.logger.info("Robot %s initialized", self.id)
 
-    def timetable_cb(self, msg):
-        robot_id = msg['payload']['timetable']['robot_id']
-        if robot_id == self.id:
-            timetable_dict = msg['payload']['timetable']
-            self.logger.debug("Robot %s received timetable msg", self.id)
-            timetable = Timetable.from_dict(timetable_dict, self.stp)
-            self.db_interface.update_timetable(timetable)
-
-    def delete_task_cb(self, msg):
-        task_dict = msg['payload']['task']
-        task = self.task_cls.from_dict(task_dict)
-        self.logger.debug("Deleting task %s ", task.id)
-        self.db_interface.remove_task(task.id)
-
     def run(self):
         try:
             self.api.start()

--- a/mrs/robot_base.py
+++ b/mrs/robot_base.py
@@ -5,7 +5,6 @@ from ropod.utils.timestamp import TimeStamp
 from stn.stp import STP
 
 from mrs.db_interface import DBInterface
-from mrs.structs.timetable import Timetable
 
 
 class RobotBase(object):
@@ -18,10 +17,9 @@ class RobotBase(object):
         task_class_path = task_type.get('class', 'mrs.structs.task')
         self.task_cls = getattr(import_module(task_class_path), 'Task')
 
-        self.timetable = Timetable.get_timetable(self.db_interface, self.id, self.stp)
-        self.db_interface.update_timetable(self.timetable)
+        self.timetable = self.db_interface.get_timetable(robot_id, self.stp)
 
         today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        self.ztp = TimeStamp()
-        self.ztp.timestamp = today_midnight
+        self.timetable.zero_timepoint = TimeStamp()
+        self.timetable.zero_timepoint.timestamp = today_midnight
 

--- a/mrs/structs/allocation.py
+++ b/mrs/structs/allocation.py
@@ -5,14 +5,14 @@ from ropod.utils.timestamp import TimeStamp
 
 
 class TaskAnnouncement(object):
-    def __init__(self, tasks, round_id, ztp):
+    def __init__(self, tasks, round_id, zero_timepoint):
         """
         Constructor for the TaskAnnouncement object
 
         Args:
              tasks (list): List of Task objects to be announced
              round_id (str): A string of the format UUID that identifies the round
-             ztp (TimeStamp): Zero Time Point. Origin time to which task temporal information must be referenced to
+             zero_timepoint (TimeStamp): Zero Time Point. Origin time to which task temporal information must be referenced to
         """
         self.tasks = tasks
 
@@ -21,7 +21,7 @@ class TaskAnnouncement(object):
         else:
             self.round_id = round_id
 
-        self.ztp = ztp
+        self.zero_timepoint = zero_timepoint
 
         delta = timedelta(minutes=1)
         self.earliest_navigation_start = TimeStamp(delta)
@@ -34,7 +34,7 @@ class TaskAnnouncement(object):
             task_annoucement_dict['tasks'][task.id] = task.to_dict()
 
         task_annoucement_dict['round_id'] = self.round_id
-        task_annoucement_dict['ztp'] = self.ztp.to_str()
+        task_annoucement_dict['zero_timepoint'] = self.zero_timepoint.to_str()
         task_annoucement_dict['earliest_navigation_start'] = self.earliest_navigation_start
 
         return task_annoucement_dict
@@ -42,14 +42,14 @@ class TaskAnnouncement(object):
     @staticmethod
     def from_dict(task_annoucement_dict, task_cls):
         round_id = task_annoucement_dict['round_id']
-        ztp = TimeStamp.from_str(task_annoucement_dict['ztp'])
+        zero_timepoint = TimeStamp.from_str(task_annoucement_dict['zero_timepoint'])
 
         tasks_dict = task_annoucement_dict['tasks']
         tasks = list()
         for task_id, task_dict in tasks_dict.items():
             tasks.append(task_cls.from_dict(task_dict))
 
-        task_announcement = TaskAnnouncement(tasks, round_id, ztp)
+        task_announcement = TaskAnnouncement(tasks, round_id, zero_timepoint)
         task_announcement.earliest_navigation_start = task_annoucement_dict['earliest_navigation_start']
 
         return task_announcement

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -114,7 +114,7 @@ class Auctioneer(object):
         timetable.solve_stp()
 
         # Update schedule to reflect the changes in the dispatchable graph
-        if timetable.is_scheduled():
+        if timetable.schedule:
             # TODO: Request re-scheduling to the scheduler via pyre
             pass
 

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -43,8 +43,7 @@ class Auctioneer(object):
         # TODO: Inititalize the timetables in the loader? and read the timetables here
         self.timetables = dict()
         for robot_id in robot_ids:
-            timetable = Timetable.get_timetable(self.db_interface, robot_id, self.stp)
-            self.db_interface.add_timetable(timetable)
+            timetable = self.db_interface.get_timetable(robot_id, self.stp)
             self.timetables[robot_id] = timetable
 
         self.tasks_to_allocate = dict()
@@ -52,10 +51,10 @@ class Auctioneer(object):
         self.waiting_for_user_confirmation = list()
         self.round = Round()
 
-        # TODO: Update ztp
+        # TODO: Update zero_timepoint
         today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        self.ztp = TimeStamp()
-        self.ztp.timestamp = today_midnight
+        self.zero_timepoint = TimeStamp()
+        self.zero_timepoint.timestamp = today_midnight
 
     def __str__(self):
         to_print = "Auctioneer"
@@ -109,7 +108,8 @@ class Auctioneer(object):
 
     def update_timetable(self, robot_id, task, position):
         timetable = self.db_interface.get_timetable(robot_id, self.stp)
-        timetable.add_task_to_stn(task, self.ztp, position)
+        timetable.zero_timepoint = self.zero_timepoint
+        timetable.add_task_to_stn(task, position)
         print("STN: ", timetable.stn)
         timetable.solve_stp()
 
@@ -160,7 +160,7 @@ class Auctioneer(object):
         self.logger.info("Number of tasks to allocate: %s", len(self.tasks_to_allocate))
 
         tasks = list(self.tasks_to_allocate.values())
-        task_announcement = TaskAnnouncement(tasks, self.round.id, self.ztp)
+        task_announcement = TaskAnnouncement(tasks, self.round.id, self.zero_timepoint)
         msg = self.api.create_message(task_announcement)
 
         self.logger.debug('task annoucement msg: %s', msg)
@@ -205,14 +205,14 @@ class Auctioneer(object):
         relative_latest_finish_time = timetable.dispatchable_graph.get_task_time(task_id, "finish", False)
 
         self.logger.debug("Current time %s: ", TimeStamp())
-        self.logger.debug("ztp %s: ", self.ztp)
+        self.logger.debug("zero_timepoint %s: ", self.zero_timepoint)
         self.logger.debug("Relative start navigation time: %s", relative_start_navigation_time)
         self.logger.debug("Relative start time: %s", relative_start_time)
         self.logger.debug("Relative latest finish time: %s", relative_latest_finish_time)
 
-        start_navigation_time = self.ztp + timedelta(minutes=relative_start_navigation_time)
-        start_time = self.ztp + timedelta(minutes=relative_start_time)
-        finish_time = self.ztp + timedelta(minutes=relative_latest_finish_time)
+        start_navigation_time = self.zero_timepoint + timedelta(minutes=relative_start_navigation_time)
+        start_time = self.zero_timepoint + timedelta(minutes=relative_start_time)
+        finish_time = self.zero_timepoint + timedelta(minutes=relative_latest_finish_time)
 
         self.logger.debug("Start navigation of task %s: %s", task_id, start_navigation_time)
         self.logger.debug("Start of task %s: %s", task_id, start_time)
@@ -226,9 +226,9 @@ class Auctioneer(object):
 
 if __name__ == '__main__':
 
-    from fleet_management.config.loader import Config
+    from fleet_management.config.loader import Configurator
     config_file_path = '../../config/config.yaml'
-    config = Config(config_file_path, initialize=True)
+    config = Configurator(config_file_path, initialize=True)
     auctioneer = config.configure_auctioneer(config.ccu_store)
 
     time.sleep(5)

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -170,11 +170,6 @@ class Auctioneer(object):
         self.round.start()
         self.api.publish(msg, groups=['TASK-ALLOCATION'])
 
-    def send_timetable(self, robot_id):
-        timetable = Timetable.get_timetable(self.db_interface, robot_id, self.stp)
-        msg = self.api.create_message(timetable)
-        self.api.publish(msg)
-
     def allocate_task_cb(self, msg):
         self.logger.debug("Task received")
         task_dict = msg['payload']['task']

--- a/mrs/task_allocation/bidder.py
+++ b/mrs/task_allocation/bidder.py
@@ -90,18 +90,14 @@ class Bidder(RobotBase):
     def insert_task(self, task, round_id):
         best_bid = None
 
-        tasks = self.timetable.get_tasks()
-        if tasks:
-            n_tasks = len(tasks)
-        else:
-            n_tasks = 0
+        n_tasks = len(self.timetable.get_tasks())
 
         # Add task to the STN from position 1 onwards (position 0 is reserved for the zero_timepoint)
         for position in range(1, n_tasks+2):
             # TODO check if the robot can make it to the task, if not, return
 
             self.logger.debug("Schedule: %s", self.timetable.schedule)
-            if position == 1 and self.timetable.is_scheduled():
+            if position == 1 and self.timetable.schedule:
                 self.logger.debug("Not adding task in position %s", position)
                 continue
 

--- a/mrs/task_allocation/bidder.py
+++ b/mrs/task_allocation/bidder.py
@@ -33,8 +33,8 @@ class Bidder(RobotBase):
         self.logger.debug("Robot %s received TASK-ANNOUNCEMENT", self.id)
         task_announcement_msg = msg['payload']
         task_announcement = TaskAnnouncement.from_dict(task_announcement_msg, self.task_cls)
-        self.ztp = task_announcement.ztp
         self.timetable = self.db_interface.get_timetable(self.id, self.stp)
+        self.timetable.zero_timepoint = task_announcement.zero_timepoint
         self.compute_bids(task_announcement)
 
     def allocation_cb(self, msg):
@@ -104,7 +104,7 @@ class Bidder(RobotBase):
             self.logger.debug("Computing bid for task %s in position %s", task.id, position)
 
             try:
-                bid = self.bidding_rule.compute_bid(self.id, round_id, task, position, self.timetable, self.ztp)
+                bid = self.bidding_rule.compute_bid(self.id, round_id, task, position, self.timetable)
 
                 self.logger.debug("Bid: (risk metric: %s, temporal metric: %s)", bid.risk_metric, bid.temporal_metric)
 

--- a/mrs/task_allocation/bidding_rule.py
+++ b/mrs/task_allocation/bidding_rule.py
@@ -7,8 +7,8 @@ class BiddingRule(object):
         self.robustness_criterion = robustness_criterion
         self.temporal_criterion = temporal_criterion
 
-    def compute_bid(self, robot_id, round_id, task, position, timetable, ztp):
-        timetable.add_task_to_stn(task, ztp, position)
+    def compute_bid(self, robot_id, round_id, task, position, timetable):
+        timetable.add_task_to_stn(task, position)
 
         try:
             timetable.solve_stp()

--- a/mrs/task_allocator.py
+++ b/mrs/task_allocator.py
@@ -1,19 +1,19 @@
 import logging
 import time
 
-from fleet_management.config.loader import Config
+from fleet_management.config.loader import Configurator
 
 
 class TaskAllocator(object):
     def __init__(self, config_file=None):
         self.logger = logging.getLogger('mrs')
         self.logger.info("Starting MRS...")
-        self.config = Config(config_file, initialize=True)
+        self.config = Configurator(config_file, initialize=True)
         self.config.configure_logger()
         self.ccu_store = self.config.ccu_store
         self.api = self.config.api
 
-        self.auctioneer = self.config.configure_auctioneer(self.ccu_store)
+        self.auctioneer = self.config.configure_auctioneer(self.ccu_store, self.api)
         self.api.register_callbacks(self)
 
     def run(self):

--- a/tests/allocation_test.py
+++ b/tests/allocation_test.py
@@ -1,69 +1,37 @@
 import logging
 import time
-import uuid
 
-from fleet_management.config.loader import Configurator
 from fleet_management.db.ccu_store import CCUStore
 from ropod.pyre_communicator.base_class import RopodPyre
-from stn.stp import STP
-
 from ropod.utils.timestamp import TimeStamp
 from ropod.utils.uuid import generate_uuid
 
 from mrs.db_interface import DBInterface
-from mrs.structs.timetable import Timetable
 from mrs.utils.datasets import load_yaml_dataset
 
 
 class TaskRequester(RopodPyre):
-    def __init__(self, config_file):
+    def __init__(self, robot_id, config_file):
         zyre_config = {'node_name': 'task_request_test',
                        'groups': ['TASK-ALLOCATION'],
                        'message_types': ['TASK', 'ALLOCATION']}
         super().__init__(zyre_config, acknowledge=False)
 
-        config = Configurator(config_file, initialize=False)
         ccu_store = CCUStore('ropod_ccu_store')
-        self.db_interface = DBInterface(ccu_store)
+        self.ccu_store_interface = DBInterface(ccu_store)
 
-        allocator_config = config._config_params.get("plugins").get("task_allocation")
-        robot_proxy = config._config_params.get("robot_proxy")
-        stp_solver = allocator_config.get('stp_solver')
-        self.stp = STP(stp_solver)
-        self.robot_ids = config._config_params.get('resource_manager').get('resources').get('fleet')
+        robot_store = CCUStore('ropod_store_' + robot_id)
+        self.robot_store_interface = DBInterface(robot_store)
 
-        self.auctioneer_name = robot_proxy.get("bidder").get("auctioneer_name")
         self.allocations = list()
         self.n_tasks = 0
         self.terminated = False
 
-    def reset_timetables(self):
-        logging.info("Resetting timetables")
-        for robot_id in self.robot_ids:
-            timetable = Timetable(robot_id, self.stp)
-            self.db_interface.update_timetable(timetable)
-            self.send_timetable(timetable, robot_id)
-
-    def reset_tasks(self):
-        logging.info("Resetting tasks")
-        tasks_dict = self.db_interface.get_tasks()
-        for task_id, task_dict in tasks_dict.items():
-            self.db_interface.remove_task(task_id)
-            self.request_task_delete(task_dict)
-
-    def send_timetable(self, timetable, robot_id):
-        logging.debug("Sending timetable to %s", robot_id)
-        timetable_msg = dict()
-        timetable_msg['header'] = dict()
-        timetable_msg['payload'] = dict()
-        timetable_msg['header']['type'] = 'TIMETABLE'
-        timetable_msg['header']['metamodel'] = 'ropod-msg-schema.json'
-        timetable_msg['header']['msgId'] = generate_uuid()
-        timetable_msg['header']['timestamp'] = TimeStamp().to_str()
-
-        timetable_msg['payload']['metamodel'] = 'ropod-bid_round-sch(self.round_time)ema.json'
-        timetable_msg['payload']['timetable'] = timetable.to_dict()
-        self.shout(timetable_msg)
+    def tear_down(self):
+        self.logger.info("Resetting the ccu_store")
+        self.ccu_store_interface.clean()
+        self.logger.info("Resetting the robot_store")
+        self.robot_store_interface.clean()
 
     def allocate(self, tasks):
         self.n_tasks = len(tasks)
@@ -82,21 +50,6 @@ class TaskRequester(RopodPyre):
 
         task_msg['payload']['metamodel'] = 'ropod-bid_round-schema.json'
         task_msg['payload']['task'] = task.to_dict()
-
-        self.whisper(task_msg, peer=self.auctioneer_name)
-
-    def request_task_delete(self, task_dict):
-        logging.debug("Requesting delete of task %s", task_dict['id'])
-        task_msg = dict()
-        task_msg['header'] = dict()
-        task_msg['payload'] = dict()
-        task_msg['header']['type'] = 'DELETE-TASK'
-        task_msg['header']['metamodel'] = 'ropod-msg-schema.json'
-        task_msg['header']['msgId'] = generate_uuid()
-        task_msg['header']['timestamp'] = TimeStamp().to_str()
-
-        task_msg['payload']['metamodel'] = 'ropod-bid_round-schema.json'
-        task_msg['payload']['task'] = task_dict
 
         self.shout(task_msg)
 
@@ -122,25 +75,22 @@ class TaskRequester(RopodPyre):
 
 if __name__ == '__main__':
     tasks = load_yaml_dataset('data/non_overlapping_3.yaml')
-    config_file_path = '../config/config.yaml'
-
-    for task in tasks:
-        print(task.to_dict())
+    config_file = '../config/config.yaml'
+    robot_id = 'ropod_001'
 
     timeout_duration = 300  # 5 minutes
 
-    test = TaskRequester(config_file_path)
+    test = TaskRequester(robot_id, config_file)
     test.start()
 
     try:
-        time.sleep(5)
-        test.reset_timetables()
-        test.reset_tasks()
+        test.tear_down()
         time.sleep(5)
         test.allocate(tasks)
         start_time = time.time()
         while not test.terminated and start_time + timeout_duration > time.time():
             time.sleep(0.5)
+        test.tear_down()
     except (KeyboardInterrupt, SystemExit):
         print('Task request test interrupted; exiting')
 


### PR DESCRIPTION
- When a Timetable object is created, its attributes (except for stn, stp and robot_id) are None. The initial STN contains only the zero timepoint node.
- Renaming ztp to zero_timepoint
- The bidder assigns to the robot's Timetable the zero timepoint received in the task-announcement msg. Before the zero_timepoint was re-assigned every time that a bid was computed.
- Importing the Configurator from fms
- Fixing allocation_test. The test cleans the ccu_store and the robot_store before and after allocating the tasks