### PR TITLE
Add timetable manager

### DIFF
--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -117,16 +117,7 @@ class Auctioneer(object):
     def update_timetable(self, bid, task_lot):
         self.get_timetable(bid.robot_id)
         timetable = self.timetables.get(bid.robot_id)
-        timetable.zero_timepoint = self.zero_timepoint
-        timetable.add_task_to_stn(task_lot, bid.position)
-        timetable.solve_stp()
-        timetable.temporal_metric = bid.temporal_metric
-
-        # Update schedule to reflect the changes in the dispatchable graph
-        if timetable.schedule:
-            # TODO: Request re-scheduling to the scheduler via pyre
-            pass
-
+        timetable.update(self.zero_timepoint, task_lot, bid.position, bid.temporal_metric)
         self.timetables.update({bid.robot_id: timetable})
         timetable.store()
 

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -50,7 +50,9 @@ class Auctioneer(object):
             self.ccu_store = ccu_store
 
     def register_robot(self, robot_id):
+        self.logger.debug("Registering robot %s", robot_id)
         self.robot_ids.append(robot_id)
+        self.timetable_manager.register_robot(robot_id)
 
     def update_tasks_to_allocate(self):
         tasks = Task.get_tasks_by_status(TaskStatusConst.UNALLOCATED)

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -116,10 +116,7 @@ class Round(object):
 
         try:
             winning_bid = self.elect_winner()
-            round_result = (winning_bid.task_id,
-                            winning_bid.robot_id,
-                            winning_bid.position,
-                            self.time_to_allocate)
+            round_result = (winning_bid, self.time_to_allocate)
 
             if winning_bid.hard_constraints is False:
                 raise AlternativeTimeSlot(winning_bid.task_id, winning_bid.robot_id, winning_bid.alternative_start_time)

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -58,7 +58,7 @@ class MRS(object):
     def get_mrta_components(self):
         allocation_method = self.config_params.get('allocation_method')
         fleet = self.config_params.get('resource_manager').get('resources').get('fleet')
-        mrta_factory = MRTAFactory(allocation_method, fleet, experiment_config=self.experiment_config)
+        mrta_factory = MRTAFactory(allocation_method, experiment_config=self.experiment_config)
 
         config = self.config_params.get('plugins').get('mrta')
         components = mrta_factory(**config)
@@ -67,6 +67,9 @@ class MRS(object):
             if hasattr(component, 'configure'):
                 self.logger.debug("Configuring %s", component_name)
                 component.configure(api=self.api, ccu_store=self.ccu_store)
+            if hasattr(component, 'register_robot'):
+                for robot_id in fleet:
+                    component.register_robot(robot_id)
 
         return components
 

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -57,7 +57,8 @@ class MRS(object):
 
     def get_mrta_components(self):
         allocation_method = self.config_params.get('allocation_method')
-        mrta_factory = MRTAFactory(allocation_method, experiment_config=self.experiment_config)
+        fleet = self.config_params.get('resource_manager').get('resources').get('fleet')
+        mrta_factory = MRTAFactory(allocation_method, fleet, experiment_config=self.experiment_config)
 
         config = self.config_params.get('plugins').get('mrta')
         components = mrta_factory(**config)

--- a/mrs/config/builders/robot.py
+++ b/mrs/config/builders/robot.py
@@ -37,7 +37,8 @@ class RobotBuilder:
         robot_config.pop('robot_store')
 
         allocation_method = config_params.get('allocation_method')
-        mrta_factory = MRTAFactory(allocation_method, experiment_config=experiment_config)
+        fleet = [robot_id]
+        mrta_factory = MRTAFactory(allocation_method, fleet, experiment_config=experiment_config)
 
         components = mrta_factory(**robot_config)
         components.update({'api': api})

--- a/mrs/config/builders/robot.py
+++ b/mrs/config/builders/robot.py
@@ -37,8 +37,7 @@ class RobotBuilder:
         robot_config.pop('robot_store')
 
         allocation_method = config_params.get('allocation_method')
-        fleet = [robot_id]
-        mrta_factory = MRTAFactory(allocation_method, fleet, experiment_config=experiment_config)
+        mrta_factory = MRTAFactory(allocation_method, experiment_config=experiment_config)
 
         components = mrta_factory(**robot_config)
         components.update({'api': api})

--- a/mrs/config/mrta.py
+++ b/mrs/config/mrta.py
@@ -20,7 +20,7 @@ class MRTAFactory:
                           'tessi-dsc': 'dsc'
                           }
 
-    def __init__(self, allocation_method, fleet, **kwargs):
+    def __init__(self, allocation_method, **kwargs):
         """
             Registers and creates MRTA (multi-robot task allocation) components
 
@@ -48,7 +48,6 @@ class MRTAFactory:
 
         self.stp_solver = STP(stp_solver_name)
         self.timetable_manager = TimetableManager(self.stp_solver)
-        self.timetable_manager.register_fleet(fleet)
 
         self.register_component('auctioneer', Auctioneer)
         self.register_component('dispatcher', Dispatcher)

--- a/mrs/config/mrta.py
+++ b/mrs/config/mrta.py
@@ -1,13 +1,15 @@
-from mrs.allocation.auctioneer import Auctioneer
-from mrs.dispatching.dispatcher import Dispatcher
-from mrs.bidding.bidder import Bidder
-from mrs.scheduling.monitor import ScheduleMonitor
 import logging
-from stn.stp import STP
+
 from fmlib.db.mongo import MongoStore
+from mrs.allocation.auctioneer import Auctioneer
+from mrs.bidding.bidder import Bidder
+from mrs.config.experiment import ExperimentFactory
+from mrs.dispatching.dispatcher import Dispatcher
+from mrs.scheduling.monitor import ScheduleMonitor
+from mrs.timetable.manager import TimetableManager
 from mrs.utils.datasets import get_dataset_id
 from mrs.utils.datasets import load_tasks_to_db
-from mrs.config.experiment import ExperimentFactory
+from stn.stp import STP
 
 
 class MRTAFactory:
@@ -18,7 +20,7 @@ class MRTAFactory:
                           'tessi-dsc': 'dsc'
                           }
 
-    def __init__(self, allocation_method, **kwargs):
+    def __init__(self, allocation_method, fleet, **kwargs):
         """
             Registers and creates MRTA (multi-robot task allocation) components
 
@@ -45,6 +47,8 @@ class MRTAFactory:
             raise ValueError(allocation_method)
 
         self.stp_solver = STP(stp_solver_name)
+        self.timetable_manager = TimetableManager(self.stp_solver)
+        self.timetable_manager.register_fleet(fleet)
 
         self.register_component('auctioneer', Auctioneer)
         self.register_component('dispatcher', Dispatcher)
@@ -74,6 +78,7 @@ class MRTAFactory:
                 _instance = component(allocation_method=self.allocation_method,
                                       stp_solver=self.stp_solver,
                                       experiment=self.experiment,
+                                      timetable_manager=self.timetable_manager,
                                       **configuration)
                 components[component_name] = _instance
 

--- a/mrs/db/models/timetable.py
+++ b/mrs/db/models/timetable.py
@@ -20,6 +20,8 @@ TimetableManager = Manager.from_queryset(TimetableQuerySet)
 class Timetable(MongoModel):
     robot_id = fields.CharField(primary_key=True)
     zero_timepoint = fields.DateTimeField()
+    temporal_metric = fields.FloatField()
+    risk_metric = fields.FloatField()
     stn = fields.DictField()
     dispatchable_graph = fields.DictField(default=dict())
 

--- a/mrs/dispatching/dispatcher.py
+++ b/mrs/dispatching/dispatcher.py
@@ -4,12 +4,13 @@ import logging
 
 class Dispatcher(object):
 
-    def __init__(self, stp_solver,  **kwargs):
+    def __init__(self, stp_solver, timetable_manager,  **kwargs):
         self.logger = logging.getLogger('mrs.dispatcher')
         self.api = kwargs.get('api')
         self.ccu_store = kwargs.get('ccu_store')
 
         self.stp_solver = stp_solver
+        self.timetable_manager = timetable_manager
 
         self.re_allocate = kwargs.get('re_allocate', False)
         self.robot_ids = list()

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -28,10 +28,10 @@ class TimetableManager(object):
     def update_zero_timepoint(self):
         pass
 
-    def register_fleet(self, fleet):
-        for robot_id in fleet:
-            self.robot_ids.append(robot_id)
-            self.fetch_timetable(robot_id)
+    def register_robot(self, robot_id):
+        self.logger.debug("Registering robot %s", robot_id)
+        self.robot_ids.append(robot_id)
+        self.fetch_timetable(robot_id)
 
     def fetch_timetables(self):
         for robot_id in self.robot_ids:

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -1,0 +1,53 @@
+import logging
+from datetime import datetime
+
+from mrs.timetable.timetable import Timetable
+from ropod.utils.timestamp import TimeStamp
+
+
+class TimetableManager(object):
+    """
+    Manages the timetable of all the robots in the fleet
+    """
+    def __init__(self, stp_solver):
+        self.logger = logging.getLogger("mrs.timetable.manager")
+        self.robot_ids = list()
+        self.timetables = dict()
+        self.stp_solver = stp_solver
+        self.zero_timepoint = self.initialize_zero_timepoint()
+
+        self.logger.debug("TimetableManager started")
+
+    @staticmethod
+    def initialize_zero_timepoint():
+        today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+        zero_timepoint = TimeStamp()
+        zero_timepoint.timestamp = today_midnight
+        return zero_timepoint
+
+    def update_zero_timepoint(self):
+        pass
+
+    def register_fleet(self, fleet):
+        for robot_id in fleet:
+            self.robot_ids.append(robot_id)
+            self.fetch_timetable(robot_id)
+
+    def fetch_timetables(self):
+        for robot_id in self.robot_ids:
+            self.fetch_timetable(robot_id)
+
+    def fetch_timetable(self, robot_id):
+        timetable = Timetable.fetch(robot_id, self.stp_solver)
+        self.timetables[robot_id] = timetable
+
+    def update_timetable(self, robot_id, position, temporal_metric, task_lot):
+        self.fetch_timetable(robot_id)
+        timetable = self.timetables.get(robot_id)
+        timetable.update(self.zero_timepoint, task_lot, position, temporal_metric)
+        self.timetables.update({robot_id: timetable})
+        timetable.store()
+
+        self.logger.debug("STN robot %s: %s", robot_id, timetable.stn)
+        self.logger.debug("Dispatchable graph robot %s: %s", robot_id, timetable.dispatchable_graph)
+

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -226,8 +226,12 @@ class Timetable(object):
 
     def store(self):
 
-        timetable = TimetableMongo(self.robot_id, self.zero_timepoint.to_datetime(),
-                                   self.stn.to_dict(), self.dispatchable_graph.to_dict())
+        timetable = TimetableMongo(self.robot_id,
+                                   self.zero_timepoint.to_datetime(),
+                                   self.temporal_metric,
+                                   self.risk_metric,
+                                   self.stn.to_dict(),
+                                   self.dispatchable_graph.to_dict())
         timetable.save()
 
     @staticmethod
@@ -235,10 +239,11 @@ class Timetable(object):
         timetable = Timetable(robot_id, stp)
         try:
             timetable_mongo = TimetableMongo.objects.get_timetable(robot_id)
-            # TODO: Add missing arguments to TimetableMongo
             timetable.stn = timetable.stn.from_dict(timetable_mongo.stn)
             timetable.dispatchable_graph = timetable.stn.from_dict(timetable_mongo.dispatchable_graph)
             timetable.zero_timepoint = timetable_mongo.zero_timepoint
+            timetable.temporal_metric = timetable_mongo.temporal_metric
+            timetable.risk_metric = timetable_mongo.risk_metric
         except DoesNotExist as err:
             logging.warning("The timetable of robot %s does not exist %s", robot_id, err)
 

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -224,6 +224,12 @@ class Timetable(object):
 
         return timetable
 
+    def update(self, zero_timepoint, task_lot, position, temporal_metric):
+        self.zero_timepoint = zero_timepoint
+        self.add_task_to_stn(task_lot, position)
+        self.solve_stp()
+        self.temporal_metric = temporal_metric
+
     def store(self):
 
         timetable = TimetableMongo(self.robot_id,

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -251,6 +251,6 @@ class Timetable(object):
             timetable.temporal_metric = timetable_mongo.temporal_metric
             timetable.risk_metric = timetable_mongo.risk_metric
         except DoesNotExist as err:
-            logging.warning("The timetable of robot %s does not exist %s", robot_id, err)
+            logging.debug("The timetable of robot %s is empty", robot_id)
 
         return timetable


### PR DESCRIPTION
-  timetable: Add risk_metric and temporal_metric to mongo model
- timetable: Add updated method
-  timetable/manager: Add TimetableManager cls

The MRTAFactory creates one instance of the TimetableManager and passes it to the components (auctioneer, dispatcher) that need it.
The TimetableManager receives the fleet robot_ids in its `register_robot` method and uses this information to initialize the timetables of all robots in the fleet.
The TimetableManager `register_robot` method is called by the `register_robot` method of the auctioneer.
In mrta, the register_robot method is called in ccu.py
In fms, the register_robot method is called by the ResourceManager
