### PR TITLE
Fix: Crashes of mrta components with inconsistent STNs

### DIFF
--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -134,8 +134,7 @@ class Bidder(RobotBase):
                     best_bid = copy.deepcopy(bid)
 
             except NoSTPSolution:
-                self.logger.warning("The stp solver could not solve the problem for"
-                                    " task %s in position %s", task_lot.task.task_id, position)
+                self.logger.debug("The STN is inconsistent with task %s in position %s", task_lot.task.task_id, position)
 
             # Restore schedule for the next iteration
             self.timetable.remove_task_from_stn(position)

--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -49,7 +49,6 @@ class Bidder(RobotBase):
         self.logger.debug("Bidder initialized %s", self.robot_id)
 
     def task_announcement_cb(self, msg):
-        self.logger.debug("Robot %s received TASK-ANNOUNCEMENT", self.robot_id)
         payload = msg['payload']
         task_announcement = TaskAnnouncement.from_payload(payload)
         self.timetable = self.get_timetable()
@@ -78,9 +77,12 @@ class Bidder(RobotBase):
             best_bid = self.insert_task(task_lot, round_id)
 
             if best_bid:
+                self.logger.debug("Best bid for task %s: (risk metric: %s, temporal metric: %s)", task_lot.task.task_id,
+                                  best_bid.risk_metric, best_bid.temporal_metric)
+
                 bids.append(best_bid)
             else:
-                self.logger.debug("No bid for task %s", task_lot.task_id)
+                self.logger.warning("No bid for task %s", task_lot.task.task_id)
                 no_bid = Bid(self.robot_id, round_id, task_lot.task.task_id)
                 no_bids.append(no_bid)
 
@@ -139,9 +141,6 @@ class Bidder(RobotBase):
             # Restore schedule for the next iteration
             self.timetable.remove_task_from_stn(position)
 
-        self.logger.debug("Best bid for task %s: (risk metric: %s, temporal metric: %s)", task_lot.task.task_id,
-                          best_bid.risk_metric, best_bid.temporal_metric)
-
         return best_bid
 
     @staticmethod
@@ -159,9 +158,6 @@ class Bidder(RobotBase):
                     (bid == smallest_bid and bid.task_id < smallest_bid.task_id):
 
                 smallest_bid = copy.deepcopy(bid)
-
-        if smallest_bid is None:
-            return None
 
         return smallest_bid
 

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -53,6 +53,10 @@ class TaskLot(MongoModel):
     def get_task(cls, task_id):
         return cls.objects.get_task(task_id)
 
+    def set_soft_constraints(self):
+        self.constraints.hard = False
+        self.save()
+
     @classmethod
     def from_payload(cls, payload):
         document = Document.from_payload(payload)

--- a/mrs/exceptions/allocation.py
+++ b/mrs/exceptions/allocation.py
@@ -1,18 +1,15 @@
 class AlternativeTimeSlot(Exception):
 
-    def __init__(self, task_id, robot_id, alternative_start_time):
+    def __init__(self, bid, time_to_allocate):
         """
         Raised when a task could not be allocated at the desired time slot.
 
-        :param task_id:
-        :param robot_id:
-        :param alternative_start_time: earliest start time at which the task can start
-                                    (lower bound of the dispatchable graph)
+        bid (obj): winning bid for the alternative timeslot
+        time_to_allocate (float)
         """
-        Exception.__init__(self, task_id, robot_id, alternative_start_time)
-        self.task_id = task_id
-        self.robot_id = robot_id
-        self.alternative_start_time = alternative_start_time
+        Exception.__init__(self, bid, time_to_allocate)
+        self.bid = bid
+        self.time_to_allocate = time_to_allocate
 
 
 class NoAllocation(Exception):


### PR DESCRIPTION
Problem: MRTA crashed when no bid was placed during an allocation round. 
The bid returned by the `insert_task` method was None and thus, it crashed when the bidder tried to access bid arguments from a None object.
- bidder: Fix crash so that the bidder sends the `no_bid` to the auctioneer.
- round: Set task temporal constraints to soft if no bids for that task were received in the round. 
- timetable: Add case for adding a task with soft constraints to the STN.
- bidding/rule: Fix computation of bid for task with soft constraints. Use relative times to the zero_tiempoint to compute the bid cost. 
- auctioneer: Accept alternative timeslot. Before, the alternative timeslot was added to a dict  `waiting for user confirmation` and no other action was taken. Now, the suggestion is always accepted. (Provisional fix until the feature for asking for user confirmation is added).
