### PR TITLE
Fix: Handle inconsistent STN in auctioneer

### DIFF
--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -124,7 +124,7 @@ class Round(object):
             return round_result
 
         except NoAllocation:
-            self.logger.error("No allocation made in round %s ", self.id)
+            self.logger.warning("No allocation made in round %s ", self.id)
             raise NoAllocation(self.id)
 
     def finish(self):

--- a/mrs/exceptions/allocation.py
+++ b/mrs/exceptions/allocation.py
@@ -28,3 +28,14 @@ class NoSTPSolution(Exception):
         """ Raised when the stp solver cannot produce a solution for the problem
         """
         Exception.__init__(self)
+
+
+class InvalidAllocation(Exception):
+
+    def __init__(self, task_id, robot_id, position):
+        """ Raised when a winning bid produces an invalid allocation
+
+        """
+        self.task_id = task_id
+        self.robot_id = robot_id
+        self.position = position

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -44,7 +44,7 @@ class TimetableManager(object):
     def update_timetable(self, robot_id, position, temporal_metric, task_lot):
         self.fetch_timetable(robot_id)
         timetable = self.timetables.get(robot_id)
-        timetable.update(self.zero_timepoint, task_lot, position, temporal_metric)
+        timetable.update(self.zero_timepoint, robot_id, task_lot, position, temporal_metric)
         self.timetables.update({robot_id: timetable})
         timetable.store()
 

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -87,10 +87,6 @@ class Timetable(object):
             task_lot (obj): task_lot object to be converted
             zero_timepoint (TimeStamp): Zero Time Point. Origin time to which task temporal information is referenced to
         """
-        delta = timedelta(minutes=1)
-        earliest_navigation_start = TimeStamp(delta)
-        r_earliest_navigation_start = earliest_navigation_start.get_difference(self.zero_timepoint, "minutes")
-
         if not task_lot.constraints.hard:
             # Get latest finish time of task in previous position
             if position > 1:
@@ -113,6 +109,8 @@ class Timetable(object):
 
         r_earliest_start_time, r_latest_start_time = TimepointConstraints.relative_to_ztp(start_timepoint_constraints,
                                                                                           self.zero_timepoint)
+        r_earliest_navigation_start = r_earliest_start_time - 0.5
+
         stn_task = STNTask(task_lot.task.task_id,
                            r_earliest_navigation_start,
                            r_earliest_start_time,


### PR DESCRIPTION
The auctioneer solves the STP with the information in the winning bid. 

Problem: If the auctioneer uses a different earliest navigation time for the tasks than the bidder, the STN will be different and in some cases inconsistent. 

Solution:
- auctioneer: Add and catch InvalidAllocation. Raised when a winning bid produces an invalid stn. This happens when the auctioneer has different information than the robot for computing the dispatchable graph.
- timetable: Update earliest_navigation_start time to be 0.5 min before earliest_start_time. 

