### PR TITLE
robot_factory: Fix api, robot_store and timetable creation. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ before_install:
 install: skip
 
 script:
-  - docker-compose up -d mongo
-  - docker-compose up -d ccu
-  - docker-compose up -d robot
-  - docker-compose up --exit-code-from task_allocation_test
+  - docker-compose up --exit-code-from task_allocation_test task_allocation_test
+  - docker-compose logs
 after_script:
   - docker stop $(docker ps -aq)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     network_mode: "host"
     tty: true
     stdin_open: true
+    depends_on:
+      - mongo
 
   ccu:
     container_name: ccu
@@ -27,6 +29,8 @@ services:
     network_mode: "host"
     tty: true
     stdin_open: true
+    depends_on:
+      - mongo
 
   task_allocation_test:
     build: .
@@ -39,7 +43,7 @@ services:
     stdin_open: true
     depends_on:
       - mongo
-      - robot
       - ccu
+      - robot
 
 

--- a/mrs/config/robot.py
+++ b/mrs/config/robot.py
@@ -12,10 +12,6 @@ from ropod.utils.timestamp import TimeStamp
 class RobotFactory:
     def __init__(self):
         self.logger = logging.getLogger('mrta.config.components.robot')
-
-        self._api = None
-        self._robot_store = None
-        self._timetable = None
         self._components = dict()
 
         self.register_component('bidder', Bidder)
@@ -24,20 +20,20 @@ class RobotFactory:
     def register_component(self, component_name, component):
         self._components[component_name] = component
 
-    @staticmethod
-    def get_robot_api(robot_id, api_config):
+    def api(self, robot_id, api_config):
+        self.logger.debug("Creating api of %s", robot_id)
         api_config['zyre']['zyre_node']['node_name'] = robot_id
         api = API(**api_config)
         return api
 
-    @staticmethod
-    def get_robot_store(robot_id, robot_store_config):
+    def robot_store(self, robot_id, robot_store_config):
+        self.logger.debug("Creating robot_store %s", robot_id)
         robot_store_config['db_name'] = robot_store_config['db_name'] + '_' + robot_id.split('_')[1]
         robot_store = Store(**robot_store_config)
         return robot_store
 
-    @staticmethod
-    def get_robot_timetable(robot_id, stp_solver):
+    def timetable(self, robot_id, stp_solver):
+        self.logger.debug("Creating timetable %s", robot_id)
         timetable = Timetable(robot_id, stp_solver)
         timetable.fetch()
         today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -52,15 +48,12 @@ class RobotFactory:
         api_config = robot_config.pop('api')
         robot_store_config = robot_config.pop('robot_store')
 
-        if not self._api:
-            self._api = self.get_robot_api(robot_id, api_config)
-        if not self._robot_store:
-            self._robot_store = self.get_robot_store(robot_id, robot_store_config)
-        if not self._timetable:
-            self._timetable = self.get_robot_timetable(robot_id, stp_solver)
+        api = self.api(robot_id, api_config)
+        robot_store = self.robot_store(robot_id, robot_store_config)
+        timetable = self.timetable(robot_id, stp_solver)
 
-        components['api'] = self._api
-        components['robot_store'] = self._robot_store
+        components['api'] = api
+        components['robot_store'] = robot_store
 
         for component_name, configuration in robot_config.items():
             self.logger.debug("Creating %s", component_name)
@@ -69,9 +62,9 @@ class RobotFactory:
                 _instance = component(allocation_method=allocation_method,
                                       robot_id=robot_id,
                                       stp_solver=stp_solver,
-                                      api=self._api,
-                                      robot_store=self._robot_store,
-                                      timetable=self._timetable,
+                                      api=api,
+                                      robot_store=robot_store,
+                                      timetable=timetable,
                                       **configuration)
 
                 components[component_name] = _instance

--- a/mrs/tests/allocate.py
+++ b/mrs/tests/allocate.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     test.start()
 
     try:
-        time.sleep(30)
+        time.sleep(60)
         test.trigger()
         while not test.terminated:
             time.sleep(0.5)


### PR DESCRIPTION
The api, robot_store and timetable should not be instance variables.
Their creation depends on the ropod_id passed in to the __call__ method
Before this commit, the api, robot_store and timetable were only created in the
first call of the __call__ method.