### PR TITLE
Fix/timetable bidding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ before_install:
 install: skip
 
 script:
-  - docker-compose up -d mongo
-  - docker-compose up -d ccu
-  - docker-compose up -d robot
-  - docker-compose up --exit-code-from task_allocation_test
+  - docker-compose up --exit-code-from task_allocation_test task_allocation_test
+  - docker-compose logs
 after_script:
   - docker stop $(docker ps -aq)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     network_mode: "host"
     tty: true
     stdin_open: true
+    depends_on:
+      - mongo
 
   ccu:
     container_name: ccu
@@ -27,6 +29,8 @@ services:
     network_mode: "host"
     tty: true
     stdin_open: true
+    depends_on:
+      - mongo
 
   task_allocation_test:
     build: .
@@ -39,7 +43,7 @@ services:
     stdin_open: true
     depends_on:
       - mongo
-      - robot
       - ccu
+      - robot
 
 

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -99,7 +99,7 @@ class Auctioneer(object):
     def process_allocation(self, allocation, time_to_allocate,  bid):
         task_lot = self.tasks_to_allocate.pop(bid.task_id)
         try:
-            self.timetable_manager.update_timetable(bid.robot_id, bid.position, bid.temporal_metric, task_lot)
+            self.timetable_manager.update_timetable(bid.robot_id, bid.insertion_point, bid.temporal_metric, task_lot)
             self.allocations.append(allocation)
 
             self.logger.debug("Allocation: %s", allocation)

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -3,7 +3,6 @@ import logging
 import time
 from datetime import timedelta
 
-import numpy as np
 from mrs.exceptions.allocation import AlternativeTimeSlot
 from mrs.exceptions.allocation import NoAllocation
 from mrs.bidding.bid import Bid
@@ -61,7 +60,7 @@ class Round(object):
         self.logger.debug("Processing bid from robot %s: (risk metric: %s, temporal metric: %s)",
                           bid.robot_id, bid.risk_metric, bid.temporal_metric)
 
-        if bid.cost != (np.inf, np.inf):
+        if bid.cost != (None, None):
             # Process a bid
             if bid.task_id not in self.received_bids or \
                     self.update_task_bid(bid, self.received_bids[bid.task_id]):
@@ -118,7 +117,7 @@ class Round(object):
             winning_bid = self.elect_winner()
             round_result = (winning_bid, self.time_to_allocate)
 
-            if winning_bid.hard_constraints is False:
+            if winning_bid.alternative_start_time:
                 raise AlternativeTimeSlot(winning_bid, self.time_to_allocate)
 
             return round_result

--- a/mrs/bidding/bid.py
+++ b/mrs/bidding/bid.py
@@ -1,19 +1,19 @@
-import numpy as np
 from ropod.utils.uuid import from_str
 
 
 class Bid(object):
-    def __init__(self, robot_id, round_id, task_id, timetable=None, **kwargs):
+    def __init__(self, robot_id, round_id, task_id, **kwargs):
 
         self.robot_id = robot_id
         self.round_id = round_id
         self.task_id = task_id
-        self.timetable = timetable
-        self.position = kwargs.get('position')
-        self.risk_metric = kwargs.get('risk_metric', np.inf)
-        self.temporal_metric = kwargs.get('temporal_metric', np.inf)
-        self.hard_constraints = kwargs.get('hard_constraints', True)
+        self.insertion_point = kwargs.get('insertion_point')
+        self.risk_metric = kwargs.get('risk_metric')
+        self.temporal_metric = kwargs.get('temporal_metric')
         self.alternative_start_time = kwargs.get('alternative_start_time')
+
+        self.stn = None
+        self.dispatchable_graph = None
 
     def __repr__(self):
         return str(self.to_dict())
@@ -38,10 +38,9 @@ class Bid(object):
         bid_dict['robot_id'] = self.robot_id
         bid_dict['round_id'] = self.round_id
         bid_dict['task_id'] = self.task_id
-        bid_dict['position'] = self.position
+        bid_dict['insertion_point'] = self.insertion_point
         bid_dict['risk_metric'] = self.risk_metric
         bid_dict['temporal_metric'] = self.temporal_metric
-        bid_dict['hard_constraints'] = self.hard_constraints
         bid_dict['alternative_start_time'] = self.alternative_start_time
         return bid_dict
 
@@ -50,17 +49,15 @@ class Bid(object):
         robot_id = bid_dict['robotId']
         round_id = from_str(bid_dict['roundId'])
         task_id = from_str(bid_dict['taskId'])
-        position = bid_dict['position']
+        insertion_point = bid_dict['insertionPoint']
         risk_metric = bid_dict['riskMetric']
         temporal_metric = bid_dict['temporalMetric']
-        hard_constraints = bid_dict['hardConstraints']
         alternative_start_time = bid_dict['alternativeStartTime']
 
         bid = cls(robot_id, round_id, task_id,
-                  position=position,
+                  insertion_point=insertion_point,
                   risk_metric=risk_metric,
                   temporal_metric=temporal_metric,
-                  hard_constraints=hard_constraints,
                   alternative_start_time=alternative_start_time)
         return bid
 

--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -40,6 +40,7 @@ class Bidder:
         self.ccu_store = kwargs.get('ccu_store')
 
         self.logger = logging.getLogger('mrs.bidder.%s' % self.robot_id)
+        self.logger.critical("Initial timetable %s", self.timetable.stn)
 
         robustness = bidding_rule.get('robustness')
         temporal = bidding_rule.get('temporal')
@@ -128,8 +129,8 @@ class Bidder:
         for insertion_point in range(1, n_tasks+2):
             # TODO check if the robot can make it to the task, if not, return
 
-            self.logger.debug("Schedule: %s", self.timetable.schedule)
-            if insertion_point == 1 and self.timetable.schedule:
+            self.logger.debug("Schedule: %s", self.timetable.schedule.get_tasks())
+            if insertion_point == 1 and self.timetable.schedule.get_tasks():
                 self.logger.debug("Not adding task in insertion_point %s", insertion_point)
                 continue
 

--- a/mrs/bidding/rule.py
+++ b/mrs/bidding/rule.py
@@ -1,44 +1,46 @@
 from mrs.bidding.bid import Bid
-from mrs.exceptions.allocation import NoSTPSolution
+from stn.exceptions.stp import NoSTPSolution
 from fmlib.models.tasks import TimepointConstraints
 from datetime import timedelta
 
 
 class BiddingRule(object):
-    def __init__(self, robustness_criterion, temporal_criterion):
-        self.robustness_criterion = robustness_criterion
+    def __init__(self, temporal_criterion):
         self.temporal_criterion = temporal_criterion
 
-    def compute_bid(self, robot_id, round_id, task_lot, position, timetable):
-        timetable.add_task_to_stn(task_lot, position)
-
+    def compute_bid(self, robot_id, round_id, task_lot, insertion_point, timetable):
         try:
-            timetable.solve_stp()
-            timetable.compute_temporal_metric(self.temporal_criterion)
+            stn, dispatchable_graph = timetable.solve_stp(task_lot, insertion_point)
+            dispatchable_graph.compute_temporal_metric(self.temporal_criterion)
 
             if task_lot.constraints.hard:
-                bid = Bid(robot_id, round_id, task_lot.task.task_id, timetable,
-                          position=position,
-                          risk_metric=timetable.risk_metric,
-                          temporal_metric=timetable.temporal_metric)
+                bid = Bid(robot_id,
+                          round_id,
+                          task_lot.task.task_id,
+                          insertion_point=insertion_point,
+                          risk_metric=dispatchable_graph.risk_metric,
+                          temporal_metric=dispatchable_graph.temporal_metric)
 
             else:
-                r_start_time = timetable.dispatchable_graph.get_time(task_lot.task.task_id, "start")
+                r_start_time = dispatchable_graph.get_time(task_lot.task.task_id, "start")
                 start_time = timetable.zero_timepoint + timedelta(minutes=r_start_time)
-                timetable.risk_metric = 1
                 start_timepoint_constraints = task_lot.constraints.timepoint_constraints[0]
 
                 r_earliest_start_time, r_latest_start_time = TimepointConstraints.relative_to_ztp(start_timepoint_constraints,
-                                                                                                timetable.zero_timepoint)
+                                                                                                  timetable.zero_timepoint)
 
                 timetable.temporal_metric = abs(r_start_time - r_earliest_start_time)
 
-                bid = Bid(robot_id, round_id, task_lot.task.task_id, timetable,
-                          position=position,
-                          risk_metric=timetable.risk_metric,
+                bid = Bid(robot_id,
+                          round_id,
+                          task_lot.task.task_id,
+                          insertion_point=insertion_point,
+                          risk_metric=1,
                           temporal_metric=timetable.temporal_metric,
-                          hard_constraints=False,
                           alternative_start_time=start_time)
+
+            bid.stn = stn
+            bid.dispatchable_graph = dispatchable_graph
 
             return bid
 

--- a/mrs/config/robot.py
+++ b/mrs/config/robot.py
@@ -12,10 +12,6 @@ from ropod.utils.timestamp import TimeStamp
 class RobotFactory:
     def __init__(self):
         self.logger = logging.getLogger('mrta.config.components.robot')
-
-        self._api = None
-        self._robot_store = None
-        self._timetable = None
         self._components = dict()
 
         self.register_component('bidder', Bidder)
@@ -24,20 +20,20 @@ class RobotFactory:
     def register_component(self, component_name, component):
         self._components[component_name] = component
 
-    @staticmethod
-    def get_robot_api(robot_id, api_config):
+    def api(self, robot_id, api_config):
+        self.logger.debug("Creating api of %s", robot_id)
         api_config['zyre']['zyre_node']['node_name'] = robot_id
         api = API(**api_config)
         return api
 
-    @staticmethod
-    def get_robot_store(robot_id, robot_store_config):
+    def robot_store(self, robot_id, robot_store_config):
+        self.logger.debug("Creating robot_store %s", robot_id)
         robot_store_config['db_name'] = robot_store_config['db_name'] + '_' + robot_id.split('_')[1]
         robot_store = Store(**robot_store_config)
         return robot_store
 
-    @staticmethod
-    def get_robot_timetable(robot_id, stp_solver):
+    def timetable(self, robot_id, stp_solver):
+        self.logger.debug("Creating timetable %s", robot_id)
         timetable = Timetable(robot_id, stp_solver)
         timetable.fetch()
         today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -52,15 +48,12 @@ class RobotFactory:
         api_config = robot_config.pop('api')
         robot_store_config = robot_config.pop('robot_store')
 
-        if not self._api:
-            self._api = self.get_robot_api(robot_id, api_config)
-        if not self._robot_store:
-            self._robot_store = self.get_robot_store(robot_id, robot_store_config)
-        if not self._timetable:
-            self._timetable = self.get_robot_timetable(robot_id, stp_solver)
+        api = self.api(robot_id, api_config)
+        robot_store = self.robot_store(robot_id, robot_store_config)
+        timetable = self.timetable(robot_id, stp_solver)
 
-        components['api'] = self._api
-        components['robot_store'] = self._robot_store
+        components['api'] = api
+        components['robot_store'] = robot_store
 
         for component_name, configuration in robot_config.items():
             self.logger.debug("Creating %s", component_name)
@@ -69,9 +62,9 @@ class RobotFactory:
                 _instance = component(allocation_method=allocation_method,
                                       robot_id=robot_id,
                                       stp_solver=stp_solver,
-                                      api=self._api,
-                                      robot_store=self._robot_store,
-                                      timetable=self._timetable,
+                                      api=api,
+                                      robot_store=robot_store,
+                                      timetable=timetable,
                                       **configuration)
 
                 components[component_name] = _instance

--- a/mrs/config/robot.py
+++ b/mrs/config/robot.py
@@ -1,12 +1,11 @@
 import logging
+
 from fmlib.api import API
 from fmlib.config.builders import Store
 
 from mrs.bidding.bidder import Bidder
 from mrs.scheduling.monitor import ScheduleMonitor
 from mrs.timetable.timetable import Timetable
-from datetime import datetime
-from ropod.utils.timestamp import TimeStamp
 
 
 class RobotFactory:
@@ -36,9 +35,6 @@ class RobotFactory:
         self.logger.debug("Creating timetable %s", robot_id)
         timetable = Timetable(robot_id, stp_solver)
         timetable.fetch()
-        today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        timetable.zero_timepoint = TimeStamp()
-        timetable.zero_timepoint.timestamp = today_midnight
         return timetable
 
     def __call__(self, allocation_method, stp_solver, timetable_manager, **robot_config):

--- a/mrs/tests/allocate.py
+++ b/mrs/tests/allocate.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     test.start()
 
     try:
-        time.sleep(30)
+        time.sleep(60)
         test.trigger()
         while not test.terminated:
             time.sleep(0.5)

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -1,11 +1,9 @@
 import logging
-from datetime import datetime
-
-from mrs.timetable.timetable import Timetable
-from ropod.utils.timestamp import TimeStamp
 
 from stn.exceptions.stp import NoSTPSolution
+
 from mrs.exceptions.allocation import InvalidAllocation
+from mrs.timetable.timetable import Timetable
 
 
 class TimetableManager(object):
@@ -14,26 +12,21 @@ class TimetableManager(object):
     """
     def __init__(self, stp_solver):
         self.logger = logging.getLogger("mrs.timetable.manager")
-        self.robot_ids = list()
         self.timetables = dict()
         self.stp_solver = stp_solver
-        self.zero_timepoint = self.initialize_zero_timepoint()
 
         self.logger.debug("TimetableManager started")
 
-    @staticmethod
-    def initialize_zero_timepoint():
-        today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        zero_timepoint = TimeStamp()
-        zero_timepoint.timestamp = today_midnight
-        return zero_timepoint
-
-    def update_zero_timepoint(self):
-        pass
+    @property
+    def zero_timepoint(self):
+        if self.timetables:
+            any_timetable = next(iter(self.timetables.values()))
+            return any_timetable.zero_timepoint
+        else:
+            self.logger.error("The zero timepoint has not been initialized")
 
     def register_robot(self, robot_id):
         self.logger.debug("Registering robot %s", robot_id)
-        self.robot_ids.append(robot_id)
         timetable = Timetable(robot_id, self.stp_solver)
         timetable.fetch()
         self.timetables[robot_id] = timetable
@@ -45,7 +38,7 @@ class TimetableManager(object):
     def update_timetable(self, robot_id, insertion_point, temporal_metric, task_lot):
         timetable = self.timetables.get(robot_id)
         timetable.fetch()
-        timetable.zero_timepoint = self.zero_timepoint
+
         try:
             stn, dispatchable_graph = timetable.solve_stp(task_lot, insertion_point)
             dispatchable_graph.temporal_metric = temporal_metric

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from mrs.timetable.timetable import Timetable
 from ropod.utils.timestamp import TimeStamp
 
+from stn.exceptions.stp import NoSTPSolution
+from mrs.exceptions.allocation import InvalidAllocation
+
 
 class TimetableManager(object):
     """
@@ -39,11 +42,20 @@ class TimetableManager(object):
         for robot_id, timetable in self.timetables.items():
             timetable.fetch()
 
-    def update_timetable(self, robot_id, position, temporal_metric, task_lot):
+    def update_timetable(self, robot_id, insertion_point, temporal_metric, task_lot):
         timetable = self.timetables.get(robot_id)
         timetable.fetch()
-        timetable.update(self.zero_timepoint, robot_id, task_lot, position, temporal_metric)
-        self.timetables.update({robot_id: timetable})
+        timetable.zero_timepoint = self.zero_timepoint
+        try:
+            stn, dispatchable_graph = timetable.solve_stp(task_lot, insertion_point)
+            dispatchable_graph.temporal_metric = temporal_metric
+            timetable.stn = stn
+            timetable.dispatchable_graph = dispatchable_graph
+            self.timetables.update({robot_id: timetable})
+        except NoSTPSolution:
+            self.logger.warning("The STN is inconsistent with task %s in insertion point %s", task_lot.task.task_id, insertion_point)
+            raise InvalidAllocation(task_lot.task.task_id, robot_id, insertion_point)
+
         timetable.store()
 
         self.logger.debug("STN robot %s: %s", robot_id, timetable.stn)


### PR DESCRIPTION
- bidding: Add the new task to a copy of the current stn, i.e., do not modify the timetable.stn before an allocation
Before, the timetable.stn was used for computing bids. This means that during the bidding process, the timetable instance changed. This could have negative effects on other robot components that share the same timetable instance.

- bid: Rename `position` to `insertion_point`. 
- bid: Remove` hard_constraints` and `timetable` attrs. Add `stn` and `dispatchable graph`.
- timetable: Remove `temporal_metric` and `risk_metric`. These are attributes of the dispatchable graph. 

- timetable: Initialize zero timepoint, raise DoesNotExit exception if the timetable cannot be fetched from mongo.
Before, the zero timepoint was initialized in the RobotFactory and in the TimetableManager. Now, it is initialized in the Timetable object. All timetables should have the same zero timepoint.

Contains commits of #37 
Requires https://github.com/ropod-project/mrta_stn/pull/17