### PR TITLE
Schedule the earliest task in the dispatchable graph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ before_install:
 install: skip
 
 script:
-  - docker-compose up -d mongo
-  - docker-compose up -d ccu
-  - docker-compose up -d robot
-  - docker-compose up --exit-code-from task_allocation_test
+  - docker-compose up --exit-code-from task_allocation_test task_allocation_test
+  - docker-compose logs
 after_script:
   - docker stop $(docker ps -aq)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     network_mode: "host"
     tty: true
     stdin_open: true
+    depends_on:
+      - mongo
 
   ccu:
     container_name: ccu
@@ -27,6 +29,8 @@ services:
     network_mode: "host"
     tty: true
     stdin_open: true
+    depends_on:
+      - mongo
 
   task_allocation_test:
     build: .
@@ -39,7 +43,7 @@ services:
     stdin_open: true
     depends_on:
       - mongo
-      - robot
       - ccu
+      - robot
 
 

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -107,6 +107,8 @@ class Auctioneer(object):
 
             self.logger.debug("Updating task status to ALLOCATED")
             task_lot.task.update_status(TaskStatusConst.ALLOCATED)
+            task = Task.get_task(bid.task_id)
+            task.assign_robots([bid.robot_id])
 
             self.announce_winner(allocation)
 

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -99,7 +99,7 @@ class Auctioneer(object):
     def process_allocation(self, allocation, time_to_allocate,  bid):
         task_lot = self.tasks_to_allocate.pop(bid.task_id)
         try:
-            self.timetable_manager.update_timetable(bid.robot_id, bid.position, bid.temporal_metric, task_lot)
+            self.timetable_manager.update_timetable(bid.robot_id, bid.insertion_point, bid.temporal_metric, task_lot)
             self.allocations.append(allocation)
 
             self.logger.debug("Allocation: %s", allocation)

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -3,7 +3,6 @@ import logging
 import time
 from datetime import timedelta
 
-import numpy as np
 from mrs.exceptions.allocation import AlternativeTimeSlot
 from mrs.exceptions.allocation import NoAllocation
 from mrs.bidding.bid import Bid
@@ -61,7 +60,7 @@ class Round(object):
         self.logger.debug("Processing bid from robot %s: (risk metric: %s, temporal metric: %s)",
                           bid.robot_id, bid.risk_metric, bid.temporal_metric)
 
-        if bid.cost != (np.inf, np.inf):
+        if bid.cost != (None, None):
             # Process a bid
             if bid.task_id not in self.received_bids or \
                     self.update_task_bid(bid, self.received_bids[bid.task_id]):
@@ -118,7 +117,7 @@ class Round(object):
             winning_bid = self.elect_winner()
             round_result = (winning_bid, self.time_to_allocate)
 
-            if winning_bid.hard_constraints is False:
+            if winning_bid.alternative_start_time:
                 raise AlternativeTimeSlot(winning_bid, self.time_to_allocate)
 
             return round_result

--- a/mrs/bidding/bid.py
+++ b/mrs/bidding/bid.py
@@ -1,19 +1,19 @@
-import numpy as np
 from ropod.utils.uuid import from_str
 
 
 class Bid(object):
-    def __init__(self, robot_id, round_id, task_id, timetable=None, **kwargs):
+    def __init__(self, robot_id, round_id, task_id, **kwargs):
 
         self.robot_id = robot_id
         self.round_id = round_id
         self.task_id = task_id
-        self.timetable = timetable
-        self.position = kwargs.get('position')
-        self.risk_metric = kwargs.get('risk_metric', np.inf)
-        self.temporal_metric = kwargs.get('temporal_metric', np.inf)
-        self.hard_constraints = kwargs.get('hard_constraints', True)
+        self.insertion_point = kwargs.get('insertion_point')
+        self.risk_metric = kwargs.get('risk_metric')
+        self.temporal_metric = kwargs.get('temporal_metric')
         self.alternative_start_time = kwargs.get('alternative_start_time')
+
+        self.stn = None
+        self.dispatchable_graph = None
 
     def __repr__(self):
         return str(self.to_dict())
@@ -38,10 +38,9 @@ class Bid(object):
         bid_dict['robot_id'] = self.robot_id
         bid_dict['round_id'] = self.round_id
         bid_dict['task_id'] = self.task_id
-        bid_dict['position'] = self.position
+        bid_dict['insertion_point'] = self.insertion_point
         bid_dict['risk_metric'] = self.risk_metric
         bid_dict['temporal_metric'] = self.temporal_metric
-        bid_dict['hard_constraints'] = self.hard_constraints
         bid_dict['alternative_start_time'] = self.alternative_start_time
         return bid_dict
 
@@ -50,17 +49,15 @@ class Bid(object):
         robot_id = bid_dict['robotId']
         round_id = from_str(bid_dict['roundId'])
         task_id = from_str(bid_dict['taskId'])
-        position = bid_dict['position']
+        insertion_point = bid_dict['insertionPoint']
         risk_metric = bid_dict['riskMetric']
         temporal_metric = bid_dict['temporalMetric']
-        hard_constraints = bid_dict['hardConstraints']
         alternative_start_time = bid_dict['alternativeStartTime']
 
         bid = cls(robot_id, round_id, task_id,
-                  position=position,
+                  insertion_point=insertion_point,
                   risk_metric=risk_metric,
                   temporal_metric=temporal_metric,
-                  hard_constraints=hard_constraints,
                   alternative_start_time=alternative_start_time)
         return bid
 

--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -129,10 +129,14 @@ class Bidder:
         for insertion_point in range(1, n_tasks+2):
             # TODO check if the robot can make it to the task, if not, return
 
-            self.logger.debug("Schedule: %s", self.timetable.schedule.get_tasks())
-            if insertion_point == 1 and self.timetable.schedule.get_tasks():
-                self.logger.debug("Not adding task in insertion_point %s", insertion_point)
-                continue
+            if insertion_point == 1:
+                earliest_task_id = self.timetable.get_earliest_task_id()
+
+                if earliest_task_id and \
+                        Task.get_task_status(earliest_task_id).status != TaskStatusConst.ALLOCATED:
+
+                    self.logger.debug("Not adding task in insertion_point %s", insertion_point)
+                    continue
 
             self.logger.debug("Computing bid for task %s in insertion_point %s", task_lot.task.task_id, insertion_point)
             try:

--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -40,6 +40,7 @@ class Bidder:
         self.ccu_store = kwargs.get('ccu_store')
 
         self.logger = logging.getLogger('mrs.bidder.%s' % self.robot_id)
+        self.logger.critical("Initial timetable %s", self.timetable.stn)
 
         robustness = bidding_rule.get('robustness')
         temporal = bidding_rule.get('temporal')
@@ -128,8 +129,8 @@ class Bidder:
         for insertion_point in range(1, n_tasks+2):
             # TODO check if the robot can make it to the task, if not, return
 
-            self.logger.debug("Schedule: %s", self.timetable.schedule)
-            if insertion_point == 1 and self.timetable.schedule:
+            self.logger.debug("Schedule: %s", self.timetable.schedule.get_tasks())
+            if insertion_point == 1 and self.timetable.schedule.get_tasks():
                 self.logger.debug("Not adding task in insertion_point %s", insertion_point)
                 continue
 

--- a/mrs/bidding/rule.py
+++ b/mrs/bidding/rule.py
@@ -1,44 +1,46 @@
 from mrs.bidding.bid import Bid
-from mrs.exceptions.allocation import NoSTPSolution
+from stn.exceptions.stp import NoSTPSolution
 from fmlib.models.tasks import TimepointConstraints
 from datetime import timedelta
 
 
 class BiddingRule(object):
-    def __init__(self, robustness_criterion, temporal_criterion):
-        self.robustness_criterion = robustness_criterion
+    def __init__(self, temporal_criterion):
         self.temporal_criterion = temporal_criterion
 
-    def compute_bid(self, robot_id, round_id, task_lot, position, timetable):
-        timetable.add_task_to_stn(task_lot, position)
-
+    def compute_bid(self, robot_id, round_id, task_lot, insertion_point, timetable):
         try:
-            timetable.solve_stp()
-            timetable.compute_temporal_metric(self.temporal_criterion)
+            stn, dispatchable_graph = timetable.solve_stp(task_lot, insertion_point)
+            dispatchable_graph.compute_temporal_metric(self.temporal_criterion)
 
             if task_lot.constraints.hard:
-                bid = Bid(robot_id, round_id, task_lot.task.task_id, timetable,
-                          position=position,
-                          risk_metric=timetable.risk_metric,
-                          temporal_metric=timetable.temporal_metric)
+                bid = Bid(robot_id,
+                          round_id,
+                          task_lot.task.task_id,
+                          insertion_point=insertion_point,
+                          risk_metric=dispatchable_graph.risk_metric,
+                          temporal_metric=dispatchable_graph.temporal_metric)
 
             else:
-                r_start_time = timetable.dispatchable_graph.get_time(task_lot.task.task_id, "start")
+                r_start_time = dispatchable_graph.get_time(task_lot.task.task_id, "start")
                 start_time = timetable.zero_timepoint + timedelta(minutes=r_start_time)
-                timetable.risk_metric = 1
                 start_timepoint_constraints = task_lot.constraints.timepoint_constraints[0]
 
                 r_earliest_start_time, r_latest_start_time = TimepointConstraints.relative_to_ztp(start_timepoint_constraints,
-                                                                                                timetable.zero_timepoint)
+                                                                                                  timetable.zero_timepoint)
 
                 timetable.temporal_metric = abs(r_start_time - r_earliest_start_time)
 
-                bid = Bid(robot_id, round_id, task_lot.task.task_id, timetable,
-                          position=position,
-                          risk_metric=timetable.risk_metric,
+                bid = Bid(robot_id,
+                          round_id,
+                          task_lot.task.task_id,
+                          insertion_point=insertion_point,
+                          risk_metric=1,
                           temporal_metric=timetable.temporal_metric,
-                          hard_constraints=False,
                           alternative_start_time=start_time)
+
+            bid.stn = stn
+            bid.dispatchable_graph = dispatchable_graph
 
             return bid
 

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -18,7 +18,7 @@ plugins:
     auctioneer:
       round_time: 15 # seconds
       alternative_timeslots: True
-      freeze_window: 3 # seconds
+      freeze_window: 5 # seconds
     dispatcher:
       re-allocate: True
 robot_proxy:
@@ -28,7 +28,8 @@ robot_proxy:
       temporal: completion_time
     auctioneer_name: fms_zyre_api # This is completely Zyre dependent
   schedule_monitor:
-    freeze_window: 3 # seconds
+    freeze_window: 5 # seconds
+    n_tasks_sub_graph: 2
     corrective_measure: re-allocate
   robot_store:
     db_name: robot_store
@@ -47,6 +48,7 @@ robot_proxy:
         message_types: # Types of messages the node will listen to. Messages not listed will be ignored
           - TASK-ANNOUNCEMENT
           - ALLOCATION
+          - TASK
         debug_msgs: false
       acknowledge: false
       publish:
@@ -62,11 +64,17 @@ robot_proxy:
           groups: ['TASK-ALLOCATION']
           msg_type: 'FINISH-ROUND'
           method: shout
+        dispatch-request:
+          groups: ['TASK-ALLOCATION']
+          msg_type: 'DISPATCH-REQUEST'
+          method: shout
       callbacks:
         - msg_type: 'TASK-ANNOUNCEMENT'
           component: 'bidder.task_announcement_cb'
         - msg_type: 'ALLOCATION'
           component: 'bidder.allocation_cb'
+        - msg_type: 'TASK'
+          component: 'schedule_monitor.task_cb'
 
 api:
   version: 0.1.0
@@ -86,6 +94,7 @@ api:
         - BID
         - FINISH-ROUND
         - START-TEST
+        - DISPATCH-REQUEST
     acknowledge: false
     debug_messages:
       - 'TASK-REQUEST'
@@ -98,6 +107,10 @@ api:
         msg_type: 'ALLOCATION'
         groups: ['TASK-ALLOCATION']
         method: shout
+      task:
+        msg_type: 'TASK'
+        groups: ['TASK-ALLOCATION']
+        method: whisper
     callbacks:
       - msg_type: 'START-TEST'
         component: '.start_test_cb'
@@ -105,6 +118,8 @@ api:
         component: 'auctioneer.bid_cb'
       - msg_type: 'FINISH-ROUND'
         component: 'auctioneer.finish_round_cb'
+      - msg_type: 'DISPATCH-REQUEST'
+        component: 'dispatcher.dispatch_request_cb'
 
 logger:
   version: 1

--- a/mrs/config/robot.py
+++ b/mrs/config/robot.py
@@ -12,10 +12,6 @@ from ropod.utils.timestamp import TimeStamp
 class RobotFactory:
     def __init__(self):
         self.logger = logging.getLogger('mrta.config.components.robot')
-
-        self._api = None
-        self._robot_store = None
-        self._timetable = None
         self._components = dict()
 
         self.register_component('bidder', Bidder)
@@ -24,20 +20,20 @@ class RobotFactory:
     def register_component(self, component_name, component):
         self._components[component_name] = component
 
-    @staticmethod
-    def get_robot_api(robot_id, api_config):
+    def api(self, robot_id, api_config):
+        self.logger.debug("Creating api of %s", robot_id)
         api_config['zyre']['zyre_node']['node_name'] = robot_id
         api = API(**api_config)
         return api
 
-    @staticmethod
-    def get_robot_store(robot_id, robot_store_config):
+    def robot_store(self, robot_id, robot_store_config):
+        self.logger.debug("Creating robot_store %s", robot_id)
         robot_store_config['db_name'] = robot_store_config['db_name'] + '_' + robot_id.split('_')[1]
         robot_store = Store(**robot_store_config)
         return robot_store
 
-    @staticmethod
-    def get_robot_timetable(robot_id, stp_solver):
+    def timetable(self, robot_id, stp_solver):
+        self.logger.debug("Creating timetable %s", robot_id)
         timetable = Timetable(robot_id, stp_solver)
         timetable.fetch()
         today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -52,15 +48,12 @@ class RobotFactory:
         api_config = robot_config.pop('api')
         robot_store_config = robot_config.pop('robot_store')
 
-        if not self._api:
-            self._api = self.get_robot_api(robot_id, api_config)
-        if not self._robot_store:
-            self._robot_store = self.get_robot_store(robot_id, robot_store_config)
-        if not self._timetable:
-            self._timetable = self.get_robot_timetable(robot_id, stp_solver)
+        api = self.api(robot_id, api_config)
+        robot_store = self.robot_store(robot_id, robot_store_config)
+        timetable = self.timetable(robot_id, stp_solver)
 
-        components['api'] = self._api
-        components['robot_store'] = self._robot_store
+        components['api'] = api
+        components['robot_store'] = robot_store
 
         for component_name, configuration in robot_config.items():
             self.logger.debug("Creating %s", component_name)
@@ -69,9 +62,9 @@ class RobotFactory:
                 _instance = component(allocation_method=allocation_method,
                                       robot_id=robot_id,
                                       stp_solver=stp_solver,
-                                      api=self._api,
-                                      robot_store=self._robot_store,
-                                      timetable=self._timetable,
+                                      api=api,
+                                      robot_store=robot_store,
+                                      timetable=timetable,
                                       **configuration)
 
                 components[component_name] = _instance

--- a/mrs/config/robot.py
+++ b/mrs/config/robot.py
@@ -1,12 +1,11 @@
 import logging
+
 from fmlib.api import API
 from fmlib.config.builders import Store
 
 from mrs.bidding.bidder import Bidder
 from mrs.scheduling.monitor import ScheduleMonitor
 from mrs.timetable.timetable import Timetable
-from datetime import datetime
-from ropod.utils.timestamp import TimeStamp
 
 
 class RobotFactory:
@@ -36,9 +35,6 @@ class RobotFactory:
         self.logger.debug("Creating timetable %s", robot_id)
         timetable = Timetable(robot_id, stp_solver)
         timetable.fetch()
-        today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        timetable.zero_timepoint = TimeStamp()
-        timetable.zero_timepoint.timestamp = today_midnight
         return timetable
 
     def __call__(self, allocation_method, stp_solver, timetable_manager, **robot_config):

--- a/mrs/dispatching/request.py
+++ b/mrs/dispatching/request.py
@@ -1,0 +1,24 @@
+from fmlib.utils.messages import Document
+
+
+class DispatchRequest:
+
+    def __init__(self, task_id, **kwargs):
+        self.task_id = task_id
+
+    def to_dict(self):
+        dict_repr = dict()
+        dict_repr['task_id'] = self.task_id
+        return dict_repr
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_payload(payload)
+        dispatch_request = cls(**document)
+        return dispatch_request
+
+    @property
+    def meta_model(self):
+        return "dispatch-request"
+
+

--- a/mrs/exceptions/execution.py
+++ b/mrs/exceptions/execution.py
@@ -1,10 +1,13 @@
 class InconsistentSchedule(Exception):
 
-    def __init__(self, task):
-        """ Raised if attempting to schedule task causes inconsistencies with the
-        temporal constraints in the dispatchable graph
+    def __init__(self, allotted_time):
+        """ Raised when assigning a given time to a timepoint in an stn makes the
+        temporal network inconsistent, i.e., attempting to schedule a task causes
+        inconsistencies with the temporal constraints
 
-        :param task: (obj) task to be scheduled
+        allotted_time (float): time (relative to the zero timepoint) assigned to the stn
         """
-        Exception.__init__(self, task)
-        self.task = task
+        Exception.__init__(self, allotted_time)
+        self.relative_time = allotted_time
+
+

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -1,4 +1,6 @@
 import logging
+from fmlib.models.tasks import Task
+from ropod.structs.task import TaskStatus as TaskStatusConst
 
 
 class ExecutorInterface:
@@ -6,4 +8,9 @@ class ExecutorInterface:
         self.robot_id = robot_id
         self.logger = logging.getLogger("mrs.executor.interface")
         self.logger.debug("Executor interface initialized %s", self.robot_id)
+
+    def execute(self, task_id):
+        self.logger.debug("Starting execution of task %s", task_id)
+        task = Task.get_task(task_id)
+        task.update_status(TaskStatusConst.ONGOING)
 

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -29,6 +29,7 @@ class Robot(object):
         try:
             self.api.start()
             while True:
+                self.schedule_monitor.run()
                 time.sleep(0.5)
         except (KeyboardInterrupt, SystemExit):
             self.logger.info("Terminating %s robot ...", self.robot_id)

--- a/mrs/scheduling/monitor.py
+++ b/mrs/scheduling/monitor.py
@@ -33,26 +33,29 @@ class ScheduleMonitor:
         """
         self.robot_id = robot_id
         self.stp_solver = stp_solver
+        self.timetable = timetable
         self.api = kwargs.get('api')
         self.ccu_store = kwargs.get('ccu_store')
-        self.timetable = timetable
 
         self.logger = logging.getLogger('mrs.schedule.monitor.%s' % self.robot_id)
 
         self.freeze_window = timedelta(minutes=freeze_window)
-
-        available_corrective_measures = self.corrective_measures.get(allocation_method)
-
-        if corrective_measure not in available_corrective_measures:
-            self.logger.error("Corrective measure %s is not avaiable for method %s", corrective_measure, allocation_method)
-            raise ValueError(corrective_measure)
-
-        self.corrective_measure = corrective_measure
+        self.corrective_measure = self.get_corrective_measure(allocation_method, corrective_measure)
 
         self.scheduler = Scheduler(self.stp_solver, self.robot_id)
         self.executor_interface = ExecutorInterface(self.robot_id)
 
         self.logger.debug("ScheduleMonitor initialized %s", self.robot_id)
+
+    def get_corrective_measure(self, allocation_method, corrective_measure):
+
+        available_corrective_measures = self.corrective_measures.get(allocation_method)
+
+        if corrective_measure not in available_corrective_measures:
+            self.logger.error("Corrective measure %s is not available for method %s", corrective_measure, allocation_method)
+            raise ValueError(corrective_measure)
+
+        return corrective_measure
 
     def configure(self, **kwargs):
         api = kwargs.get('api')

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -1,12 +1,52 @@
 import logging
+from datetime import timedelta
+
+from fmlib.models.tasks import Task
+from ropod.structs.task import TaskStatus as TaskStatusConst
+from ropod.utils.timestamp import TimeStamp
+
+from mrs.exceptions.execution import InconsistentSchedule
 
 
 class Scheduler(object):
-    def __init__(self, stp_solver, robot_id):
-        self.robot_id = robot_id
+    def __init__(self, timetable, stp_solver, robot_id, freeze_window, n_tasks_sub_graph):
+        self.timetable = timetable
         self.stp_solver = stp_solver
-        self.n_tasks_sub_graphs = 2
+        self.robot_id = robot_id
+        self.freeze_window = timedelta(seconds=freeze_window)
+        self.n_tasks_sub_graph = n_tasks_sub_graph
         self.logger = logging.getLogger("mrs.scheduler")
+        self.is_scheduling = False
 
         self.logger.debug("Scheduler initialized %s", self.robot_id)
+
+    def is_schedulable(self, start_time):
+        current_time = TimeStamp()
+        if start_time.get_difference(current_time) < self.freeze_window:
+            self.is_scheduling = True
+            return True
+
+        return False
+
+    def schedule(self, task_id):
+        r_start_time = self.timetable.get_r_time(task_id)
+        start_time = self.timetable.get_start_time(task_id)
+        finish_time = self.timetable.get_finish_time(task_id)
+        sub_stn = self.timetable.stn.get_subgraph(self.n_tasks_sub_graph)
+        try:
+            self.timetable.assign_timepoint(sub_stn, r_start_time)
+            task = Task.get_task(task_id)
+
+            task_schedule = {"start_time": start_time.to_datetime(),
+                             "finish_time": finish_time.to_datetime()}
+
+            task.update_schedule(task_schedule)
+            task.update_status(TaskStatusConst.SCHEDULED)
+            self.logger.debug("Scheduling task %s to start at %s", task_id, start_time)
+
+        except InconsistentSchedule:
+            self.logger.warning("Task %s could not be scheduled at %s", task_id, start_time)
+            # TODO: Trigger task re-allocation
+
+        self.is_scheduling = False
 

--- a/mrs/tests/allocate.py
+++ b/mrs/tests/allocate.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     test.start()
 
     try:
-        time.sleep(30)
+        time.sleep(60)
         test.trigger()
         while not test.terminated:
             time.sleep(0.5)

--- a/mrs/tests/data/non_overlapping.yaml
+++ b/mrs/tests/data/non_overlapping.yaml
@@ -6,60 +6,60 @@ lower_bound: 60
 task_type: mrs.structs.allocation
 tasks:
   002767db-01f3-4e0c-af4e-52c4d81bd713:
-    earliest_start_time: 10
+    earliest_start_time: 1
     estimated_duration: 9.12
     finish_location: second_door_outside
     hard_constraints: true
     task_id: 002767db-01f3-4e0c-af4e-52c4d81bd713
-    latest_start_time: 13
+    latest_start_time: 2
     start_location: table
     status:
       status: 1
       task_id: 002767db-01f3-4e0c-af4e-52c4d81bd713
       delayed: false
   173d27eb-d0a4-4b94-986b-1e9b8eca0579:
-    earliest_start_time: 20
+    earliest_start_time: 4
     estimated_duration: 6.84
     finish_location: second_door_outside
     hard_constraints: true
     task_id: 173d27eb-d0a4-4b94-986b-1e9b8eca0579
-    latest_start_time: 23
+    latest_start_time: 5
     start_location: inspection_area
     status:
       status: 1
       task_id: 173d27eb-d0a4-4b94-986b-1e9b8eca0579
       delayed: false
   4076f78b-16d8-4057-a1ad-d16d239764fa:
-    earliest_start_time: 30
+    earliest_start_time: 7
     estimated_duration: 2.74
     finish_location: shelf
     hard_constraints: true
     task_id: 4076f78b-16d8-4057-a1ad-d16d239764fa
-    latest_start_time: 33
+    latest_start_time: 8
     start_location: cupboard
     status:
       status: 1
       task_id: 002767db-01f3-4e0c-af4e-52c4d81bd713
       delayed: false
   6d17963b-10b5-4143-b279-84d8e93aaaa3:
-    earliest_start_time: 40
+    earliest_start_time: 10
     estimated_duration: 2.3
     finish_location: observation_pose
     hard_constraints: true
     task_id: 6d17963b-10b5-4143-b279-84d8e93aaaa3
-    latest_start_time: 43
+    latest_start_time: 11
     start_location: living_room
     status:
       status: 1
       task_id: 6d17963b-10b5-4143-b279-84d8e93aaaa3
       delayed: false
   73ace543-260e-474a-9112-3abd470ed5b5:
-    earliest_start_time: 50
+    earliest_start_time: 13
     estimated_duration: 8.24
     finish_location: kitchen
     hard_constraints: true
     task_id: 73ace543-260e-474a-9112-3abd470ed5b5
-    latest_start_time: 53
+    latest_start_time: 14
     start_location: shelf
     status:
       status: 1

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -1,11 +1,9 @@
 import logging
-from datetime import datetime
-
-from mrs.timetable.timetable import Timetable
-from ropod.utils.timestamp import TimeStamp
 
 from stn.exceptions.stp import NoSTPSolution
+
 from mrs.exceptions.allocation import InvalidAllocation
+from mrs.timetable.timetable import Timetable
 
 
 class TimetableManager(object):
@@ -14,26 +12,21 @@ class TimetableManager(object):
     """
     def __init__(self, stp_solver):
         self.logger = logging.getLogger("mrs.timetable.manager")
-        self.robot_ids = list()
         self.timetables = dict()
         self.stp_solver = stp_solver
-        self.zero_timepoint = self.initialize_zero_timepoint()
 
         self.logger.debug("TimetableManager started")
 
-    @staticmethod
-    def initialize_zero_timepoint():
-        today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        zero_timepoint = TimeStamp()
-        zero_timepoint.timestamp = today_midnight
-        return zero_timepoint
-
-    def update_zero_timepoint(self):
-        pass
+    @property
+    def zero_timepoint(self):
+        if self.timetables:
+            any_timetable = next(iter(self.timetables.values()))
+            return any_timetable.zero_timepoint
+        else:
+            self.logger.error("The zero timepoint has not been initialized")
 
     def register_robot(self, robot_id):
         self.logger.debug("Registering robot %s", robot_id)
-        self.robot_ids.append(robot_id)
         timetable = Timetable(robot_id, self.stp_solver)
         timetable.fetch()
         self.timetables[robot_id] = timetable
@@ -45,7 +38,7 @@ class TimetableManager(object):
     def update_timetable(self, robot_id, insertion_point, temporal_metric, task_lot):
         timetable = self.timetables.get(robot_id)
         timetable.fetch()
-        timetable.zero_timepoint = self.zero_timepoint
+
         try:
             stn, dispatchable_graph = timetable.solve_stp(task_lot, insertion_point)
             dispatchable_graph.temporal_metric = temporal_metric

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from mrs.timetable.timetable import Timetable
 from ropod.utils.timestamp import TimeStamp
 
+from stn.exceptions.stp import NoSTPSolution
+from mrs.exceptions.allocation import InvalidAllocation
+
 
 class TimetableManager(object):
     """
@@ -39,11 +42,20 @@ class TimetableManager(object):
         for robot_id, timetable in self.timetables.items():
             timetable.fetch()
 
-    def update_timetable(self, robot_id, position, temporal_metric, task_lot):
+    def update_timetable(self, robot_id, insertion_point, temporal_metric, task_lot):
         timetable = self.timetables.get(robot_id)
         timetable.fetch()
-        timetable.update(self.zero_timepoint, robot_id, task_lot, position, temporal_metric)
-        self.timetables.update({robot_id: timetable})
+        timetable.zero_timepoint = self.zero_timepoint
+        try:
+            stn, dispatchable_graph = timetable.solve_stp(task_lot, insertion_point)
+            dispatchable_graph.temporal_metric = temporal_metric
+            timetable.stn = stn
+            timetable.dispatchable_graph = dispatchable_graph
+            self.timetables.update({robot_id: timetable})
+        except NoSTPSolution:
+            self.logger.warning("The STN is inconsistent with task %s in insertion point %s", task_lot.task.task_id, insertion_point)
+            raise InvalidAllocation(task_lot.task.task_id, robot_id, insertion_point)
+
         timetable.store()
 
         self.logger.debug("STN robot %s: %s", robot_id, timetable.stn)


### PR DESCRIPTION
Get the earliest task in the dispatchable graph and check schedulability condition (using freeze window)
When a task is schedulable (i.e., freeze window condition is met), the schedule monitor requests the dispatcher to dispatch the task to the robot.
Once the schedule_monitor has the task, it schedules it.
When the task is ready to be executed (current_time is task.start_time), the schedule_monitor sends the task to the executor_interface

Task status transition:
allocated -> planned -> dispatched -> scheduled -> ongoing

The auctioneer does not add a new task in the first stn insertion point if the earliest_task is either dispatched, scheduled or ongoing

Contains commits of #38
Requires ropod-project/mrta_stn#18