### PR TITLE
Fix get_task_status and assign_timepoint

### DIFF
--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -130,11 +130,8 @@ class Bidder:
             # TODO check if the robot can make it to the task, if not, return
 
             if insertion_point == 1:
-                earliest_task_id = self.timetable.get_earliest_task_id()
-
-                if earliest_task_id and \
-                        Task.get_task_status(earliest_task_id).status != TaskStatusConst.ALLOCATED:
-
+                earliest_task = self.timetable.get_earliest_task()
+                if earliest_task and earliest_task.status.status != TaskStatusConst.ALLOCATED:
                     self.logger.debug("Not adding task in insertion_point %s", insertion_point)
                     continue
 

--- a/mrs/scheduling/monitor.py
+++ b/mrs/scheduling/monitor.py
@@ -80,12 +80,11 @@ class ScheduleMonitor:
         self.trigger_execution()
 
     def trigger_scheduling(self):
-        earliest_task_id = self.timetable.get_earliest_task_id()
-        if earliest_task_id and \
-                Task.get_task_status(earliest_task_id).status == TaskStatusConst.ALLOCATED:
-            start_time = self.timetable.get_start_time(earliest_task_id)
+        earliest_task = self.timetable.get_earliest_task()
+        if earliest_task and earliest_task.status.status == TaskStatusConst.ALLOCATED:
+            start_time = self.timetable.get_start_time(earliest_task.task_id)
             if self.scheduler.is_schedulable(start_time):
-                self.request_dispatch(earliest_task_id)
+                self.request_dispatch(earliest_task.task_id)
 
     def trigger_execution(self):
         scheduled_tasks = Task.get_tasks_by_status(TaskStatusConst.SCHEDULED)

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -34,7 +34,7 @@ class Scheduler(object):
         finish_time = self.timetable.get_finish_time(task_id)
         sub_stn = self.timetable.stn.get_subgraph(self.n_tasks_sub_graph)
         try:
-            self.timetable.assign_timepoint(sub_stn, r_start_time)
+            self.timetable.assign_timepoint(sub_stn, r_start_time, task_id)
             task = Task.get_task(task_id)
 
             task_schedule = {"start_time": start_time.to_datetime(),

--- a/mrs/tests/allocate.py
+++ b/mrs/tests/allocate.py
@@ -91,10 +91,11 @@ if __name__ == '__main__':
     test = AllocationTest(config)
 
     test.load_tasks(dataset)
-    test.start()
 
     try:
-        time.sleep(60)
+        time.sleep(30)
+        test.start()
+        time.sleep(30)
         test.trigger()
         while not test.terminated:
             time.sleep(0.5)

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -173,11 +173,11 @@ class Timetable(object):
         else:
             logger.error("The dispatchable graph is empty")
 
-    def assign_timepoint(self, sub_stn, allotted_time, timepoint_position=1):
-        sub_stn.assign_timepoint(allotted_time, timepoint_position)
+    def assign_timepoint(self, sub_stn, allotted_time, task_id):
+        sub_stn.assign_timepoint(allotted_time, task_id, "navigation")
         if self.stp.is_consistent(sub_stn):
-            self.dispatchable_graph.assign_timepoint(allotted_time, timepoint_position)
-            self.stn.assign_timepoint(allotted_time, timepoint_position)
+            self.dispatchable_graph.assign_timepoint(allotted_time, task_id, "navigation")
+            self.stn.assign_timepoint(allotted_time, task_id, "navigation")
             self.schedule = self.dispatchable_graph.get_subgraph(n_tasks=1)
 
         else:


### PR DESCRIPTION
- timetable: Update `get_earliest_task`. Returns task and not task_id
- Use the status property to get the status of a task
- timetable: Use the most recent version of assign_timepoint method
- tests/allocate: Sleep before starting the node