### PR TITLE
Freeze scheduled tasks and assign times to the ongoing task timepoints

### DIFF
--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -37,7 +37,7 @@ class Auctioneer(object):
         self.tasks_to_allocate = dict()
         self.allocations = list()
         self.waiting_for_user_confirmation = list()
-        self.round = Round()
+        self.round = Round(self.timetable_manager.get_n_allocated_tasks())
 
     def configure(self, **kwargs):
         api = kwargs.get('api')
@@ -64,8 +64,12 @@ class Auctioneer(object):
 
         if self.round.opened and self.round.time_to_close():
             try:
-                round_result = self.round.get_result()
-                self.process_round_result(round_result)
+                if self.round.n_allocated_tasks == self.timetable_manager.get_n_allocated_tasks():
+                    round_result = self.round.get_result()
+                    self.process_round_result(round_result)
+                else:
+                    self.logger.warning("Round has to be repeated")
+                    self.round.finish()
 
             except NoAllocation as exception:
                 self.logger.warning("No allocation made in round %s ", exception.round_id)
@@ -135,7 +139,7 @@ class Auctioneer(object):
     def announce_task(self):
         self.timetable_manager.fetch_timetables()
 
-        self.round = Round(n_robots=len(self.robot_ids),
+        self.round = Round(self.timetable_manager.get_n_allocated_tasks(),
                            round_time=self.round_time,
                            alternative_timeslots=self.alternative_timeslots)
 
@@ -165,6 +169,15 @@ class Auctioneer(object):
             allocation = Allocation(allocated_task, robot_id)
             msg = self.api.create_message(allocation)
             self.api.publish(msg, groups=['TASK-ALLOCATION'])
+
+    def archive_task(self, robot_id, task_id, node_id):
+        self.logger.debug("Deleting task %s", task_id)
+        timetable = self.timetable_manager.get_timetable(robot_id)
+        timetable.remove_task(node_id)
+        task = Task.get_task(task_id)
+        task.update_status(TaskStatusConst.COMPLETED)
+        self.logger.debug("STN robot %s: %s", robot_id, timetable.stn)
+        self.logger.debug("Dispatchable graph robot %s: %s", robot_id, timetable.dispatchable_graph)
 
     def get_task_schedule(self, task_id, robot_id):
         # For now, returning the start navigation time from the dispatchable graph

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -119,18 +119,18 @@ class Auctioneer(object):
             self.tasks_to_allocate[task_lot.task.task_id] = task_lot
             self.round.finish()
 
-    def add_task(self, task):
-        task_lot = TaskLot.from_task(task)
-        self.tasks_to_allocate[task_lot.task.task_id] = task_lot
-
     def allocate(self, tasks):
+        tasks_to_allocate = dict()
         if isinstance(tasks, list):
-            for task in tasks:
-                self.add_task(task)
             self.logger.debug('Auctioneer received a list of tasks')
+            for task in tasks:
+                task_lot = TaskLot.from_task(task)
+                tasks_to_allocate[task_lot.task.task_id] = task_lot
         else:
-            self.add_task(tasks)
             self.logger.debug('Auctioneer received one task')
+            task_lot = TaskLot.from_task(tasks)
+            tasks_to_allocate[task_lot.task.task_id] = task_lot
+        self.tasks_to_allocate = tasks_to_allocate
 
     def announce_task(self):
         self.timetable_manager.fetch_timetables()

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -13,11 +13,10 @@ from mrs.db.models.task import TaskLot
 
 class Round(object):
 
-    def __init__(self, n_robots=1, round_time=timedelta(seconds=5), **kwargs):
+    def __init__(self,  n_allocated_tasks, round_time=timedelta(seconds=5), **kwargs):
 
         self.logger = logging.getLogger('mrs.auctioneer.round')
-
-        self.n_robots = n_robots
+        self.n_allocated_tasks = n_allocated_tasks
         self.round_time = round_time
         self.alternative_timeslots = kwargs.get('alternative_timeslots', False)
 

--- a/mrs/bidding/bidder.py
+++ b/mrs/bidding/bidder.py
@@ -40,7 +40,7 @@ class Bidder:
         self.ccu_store = kwargs.get('ccu_store')
 
         self.logger = logging.getLogger('mrs.bidder.%s' % self.robot_id)
-        self.logger.critical("Initial timetable %s", self.timetable.stn)
+        self.logger.debug("Initial timetable %s", self.timetable.stn)
 
         robustness = bidding_rule.get('robustness')
         temporal = bidding_rule.get('temporal')
@@ -205,4 +205,12 @@ class Bidder:
 
         self.logger.debug("Robot %s sends close round msg ", self.robot_id)
         self.api.publish(msg, groups=['TASK-ALLOCATION'])
+
+    def archive_task(self, robot_id, task_id, node_id):
+        self.logger.debug("Deleting task %s", task_id)
+        self.timetable.remove_task(node_id)
+        self.logger.debug("STN robot %s: %s", robot_id, self.timetable.stn)
+        self.logger.debug("Dispatchable graph robot %s: %s", robot_id, self.timetable.dispatchable_graph)
+        # task = Task.get_task(task_id)
+        # task.update_status(TaskStatusConst.COMPLETED)
 

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -8,6 +8,7 @@ from fmlib.config.params import ConfigParams
 from fmlib.models.tasks import Task
 from mrs.config.mrta import MRTAFactory
 from ropod.structs.task import TaskStatus as TaskStatusConst
+from mrs.execution.archive_task import ArchiveTask
 
 ConfigParams.default_config_module = 'mrs.config.default'
 
@@ -65,6 +66,12 @@ class MRS(object):
         self.logger.debug("Start test msg received")
         tasks = Task.get_tasks_by_status(TaskStatusConst.UNALLOCATED)
         self.auctioneer.allocate(tasks)
+
+    def archive_task_cb(self, msg):
+        payload = msg['payload']
+        archive_task = ArchiveTask.from_payload(payload)
+        self.auctioneer.archive_task(archive_task.robot_id, archive_task.task_id, archive_task.node_id)
+        self.dispatcher.timetable_manager.send_update_to = archive_task.robot_id
 
     def run(self):
         try:

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -58,6 +58,10 @@ robot_proxy:
           groups: ['TASK-ALLOCATION']
           msg_type: 'FINISH-ROUND'
           method: shout
+        archive-task:
+          groups: ['TASK-ALLOCATION']
+          msg_type: 'ARCHIVE-TASK'
+          method: shout
       callbacks:
         - msg_type: 'TASK-ANNOUNCEMENT'
           component: 'bidder.task_announcement_cb'
@@ -86,6 +90,7 @@ api:
         - BID
         - FINISH-ROUND
         - START-TEST
+        - ARCHIVE-TASK
     acknowledge: false
     debug_messages:
       - 'TASK-REQUEST'
@@ -113,6 +118,8 @@ api:
         component: 'auctioneer.bid_cb'
       - msg_type: 'FINISH-ROUND'
         component: 'auctioneer.finish_round_cb'
+      - msg_type: 'ARCHIVE-TASK'
+        component: '.archive_task_cb'
 logger:
   version: 1
   formatters:

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -28,6 +28,7 @@ robot_proxy:
     auctioneer_name: fms_zyre_api # This is completely Zyre dependent
   executor_interface:
     corrective_measure: re-allocate
+    time_resolution: 0.5 # minutes
   robot_store:
     db_name: robot_store
     port: 27017

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -63,7 +63,7 @@ robot_proxy:
         - msg_type: 'ALLOCATION'
           component: 'bidder.allocation_cb'
         - msg_type: 'D-GRAPH-UPDATE'
-          component: 'executor_interface.d_graph_update_cb'
+          component: 'executor_interface.schedule_monitor.d_graph_update_cb'
         - msg_type: 'TASK'
           component: 'executor_interface.task_cb'
         - msg_type: 'TASK'

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -14,6 +14,7 @@ class TaskLot(MongoModel):
     start_location = fields.CharField()
     finish_location = fields.CharField()
     constraints = fields.EmbeddedDocumentField(TaskConstraints)
+    frozen = fields.BooleanField(default=False)
 
     objects = TaskManager()
 
@@ -58,11 +59,18 @@ class TaskLot(MongoModel):
         self.save()
 
     @classmethod
+    def freeze_task(cls, task_id):
+        task = cls.get_task(task_id)
+        task.frozen = True
+        task.save()
+
+    @classmethod
     def from_payload(cls, payload):
         document = Document.from_payload(payload)
         document['_id'] = document.pop('task_id')
         document["constraints"] = TaskConstraints.from_payload(document.pop("constraints"))
         task_lot = TaskLot.from_document(document)
+        task_lot.save()
         return task_lot
 
     def to_dict(self):

--- a/mrs/dispatching/d_graph_update.py
+++ b/mrs/dispatching/d_graph_update.py
@@ -2,11 +2,13 @@ from fmlib.utils.messages import Document
 
 
 class DGraphUpdate:
-    def __init__(self, dispatchable_graph, **kwargs):
+    def __init__(self, zero_timepoint, dispatchable_graph, **kwargs):
+        self.zero_timepoint = zero_timepoint
         self.dispatchable_graph = dispatchable_graph
 
     def to_dict(self):
         dict_repr = dict()
+        dict_repr['zero_timepoint'] = self.zero_timepoint.to_str()
         dict_repr['dispatchable_graph'] = self.dispatchable_graph.to_dict()
         return dict_repr
 

--- a/mrs/dispatching/dispatcher.py
+++ b/mrs/dispatching/dispatcher.py
@@ -49,13 +49,13 @@ class Dispatcher(object):
         self.robot_ids.append(robot_id)
 
     def run(self):
+        self.dispatch_tasks()
+
         if self.timetable_manager.send_update_to:
             robot_id = self.timetable_manager.send_update_to
             self.timetable_manager.send_update_to = None
             timetable = self.timetable_manager.get_timetable(robot_id)
             self.send_d_graph_update(timetable, robot_id)
-
-        self.dispatch_tasks()
 
     def dispatch_tasks(self):
         for robot_id in self.robot_ids:

--- a/mrs/dispatching/dispatcher.py
+++ b/mrs/dispatching/dispatcher.py
@@ -5,6 +5,7 @@ from ropod.structs.task import TaskStatus as TaskStatusConst
 
 from mrs.dispatching.schedule_monitor import ScheduleMonitor
 from mrs.dispatching.d_graph_update import DGraphUpdate
+from mrs.db.models.task import TaskLot
 
 
 class Dispatcher(object):
@@ -48,12 +49,13 @@ class Dispatcher(object):
         self.robot_ids.append(robot_id)
 
     def run(self):
-        self.dispatch_tasks()
         if self.timetable_manager.send_update_to:
             robot_id = self.timetable_manager.send_update_to
             self.timetable_manager.send_update_to = None
             timetable = self.timetable_manager.get_timetable(robot_id)
             self.send_d_graph_update(timetable, robot_id)
+
+        self.dispatch_tasks()
 
     def dispatch_tasks(self):
         for robot_id in self.robot_ids:
@@ -63,6 +65,7 @@ class Dispatcher(object):
                 if task.status.status == TaskStatusConst.PLANNED:
                     start_time = timetable.get_start_time(task.task_id)
                     if self.schedule_monitor.is_schedulable(start_time):
+                        TaskLot.freeze_task(task.task_id)
                         self.dispatch_task(task, robot_id)
 
     def dispatch_task(self, task, robot_id):
@@ -79,6 +82,7 @@ class Dispatcher(object):
         task.update_status(TaskStatusConst.DISPATCHED)
 
     def send_d_graph_update(self, timetable, robot_id):
+        self.logger.debug("Sending DGraphUpdate to %s", robot_id)
         sub_dispatchable_graph = timetable.dispatchable_graph.get_subgraph(n_tasks=self.timetable_manager.n_tasks_queue)
         d_graph_update = DGraphUpdate(self.timetable_manager.zero_timepoint, sub_dispatchable_graph)
         d_graph_update_msg = self.api.create_message(d_graph_update)

--- a/mrs/dispatching/dispatcher.py
+++ b/mrs/dispatching/dispatcher.py
@@ -80,7 +80,7 @@ class Dispatcher(object):
 
     def send_d_graph_update(self, timetable, robot_id):
         sub_dispatchable_graph = timetable.dispatchable_graph.get_subgraph(n_tasks=self.timetable_manager.n_tasks_queue)
-        d_graph_update = DGraphUpdate(sub_dispatchable_graph)
+        d_graph_update = DGraphUpdate(self.timetable_manager.zero_timepoint, sub_dispatchable_graph)
         d_graph_update_msg = self.api.create_message(d_graph_update)
         self.api.publish(d_graph_update_msg, peer=robot_id)
 

--- a/mrs/dispatching/schedule_monitor.py
+++ b/mrs/dispatching/schedule_monitor.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 from ropod.utils.timestamp import TimeStamp
@@ -14,10 +15,13 @@ class ScheduleMonitor:
                         start navigation time is within the next 2 minutes.
 
         """
+        self.logger = logging.getLogger('mrs.schedule_monitor')
         self.freeze_window = timedelta(seconds=freeze_window)
+        self.logger.debug("Schedule Monitor started")
 
     def is_schedulable(self, start_time):
         current_time = TimeStamp()
         if start_time.get_difference(current_time) < self.freeze_window:
             return True
         return False
+

--- a/mrs/exceptions/execution.py
+++ b/mrs/exceptions/execution.py
@@ -11,3 +11,15 @@ class InconsistentSchedule(Exception):
         self.relative_time = allotted_time
 
 
+class MissingDispatchableGraph(Exception):
+    def __init__(self, robot_id):
+        """
+        Raised when a component does not have a dispatchable graph
+        Args:
+            robot_id (str):  id of the robot, e.g. ropod_001
+
+        """
+        Exception.__init__(self, robot_id)
+        self.robot_id = robot_id
+
+

--- a/mrs/exceptions/execution.py
+++ b/mrs/exceptions/execution.py
@@ -1,14 +1,18 @@
 class InconsistentSchedule(Exception):
 
-    def __init__(self, allotted_time):
-        """ Raised when assigning a given time to a timepoint in an stn makes the
-        temporal network inconsistent, i.e., attempting to schedule a task causes
+    def __init__(self, earliest_time, latest_time):
+        """ Trying to assign a time (between earliest_time and latest_time)
+         to a timepoint in an stn makes the temporal network inconsistent.
+
+        e.g., attempting to schedule a task causes
         inconsistencies with the temporal constraints
 
-        allotted_time (float): time (relative to the zero timepoint) assigned to the stn
+        earliest_time (float): time relative to the zero timepoint
+        latest_time (float): time relative to the zero timepoint
         """
-        Exception.__init__(self, allotted_time)
-        self.relative_time = allotted_time
+        Exception.__init__(self, earliest_time, latest_time)
+        self.earliest_time = earliest_time
+        self.latest_time = latest_time
 
 
 class MissingDispatchableGraph(Exception):

--- a/mrs/execution/archive_task.py
+++ b/mrs/execution/archive_task.py
@@ -1,0 +1,26 @@
+from fmlib.utils.messages import Document
+
+
+class ArchiveTask:
+    def __init__(self, robot_id, task_id, node_id, **kwargs):
+        self.robot_id = robot_id
+        self.task_id = task_id
+        self.node_id = node_id
+
+    def to_dict(self):
+        dict_repr = dict()
+        dict_repr['robot_id'] = self.robot_id
+        dict_repr['task_id'] = self.task_id
+        dict_repr['node_id'] = self.node_id
+        return dict_repr
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_payload(payload)
+        archive_task = cls(**document)
+        return archive_task
+
+    @property
+    def meta_model(self):
+        return "archive-task"
+

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -1,11 +1,9 @@
 import logging
+
 from fmlib.models.tasks import Task
-from mrs.dispatching.d_graph_update import DGraphUpdate
 from ropod.structs.task import TaskStatus as TaskStatusConst
+
 from mrs.scheduling.monitor import ScheduleMonitor
-import networkx as nx
-from stn.stn import STN
-from ropod.utils.timestamp import TimeStamp
 
 
 class ExecutorInterface:
@@ -22,8 +20,6 @@ class ExecutorInterface:
                                                 allocation_method,
                                                 corrective_measure)
         self.queued_tasks = list()
-        self.dispatchable_graph = None
-        self.zero_timepoint = None
         self.logger = logging.getLogger("mrs.executor.interface.%s" % self.robot_id)
         self.logger.debug("Executor interface initialized %s", self.robot_id)
 
@@ -32,36 +28,10 @@ class ExecutorInterface:
         task = Task.get_task(task_id)
         task.update_status(TaskStatusConst.ONGOING)
 
-    def update_dispatchable_graph(self, dispatchable_graph):
-        current_task_ids = self.dispatchable_graph.get_tasks()
-        new_task_ids = dispatchable_graph.get_tasks()
-
-        for task_id in new_task_ids:
-            if task_id not in current_task_ids:
-                # Get graph with new task
-                node_ids = dispatchable_graph.get_task_node_ids(task_id)
-                node_ids.insert(0, 0)
-                task_graph = dispatchable_graph.subgraph(node_ids)
-
-                # Update dispatchable graph to include new task
-                self.dispatchable_graph = nx.compose(self.dispatchable_graph, task_graph)
-
     def task_cb(self, msg):
         payload = msg['payload']
         task = Task.from_payload(payload)
         self.logger.debug("Received task %s", task.task_id)
         if self.robot_id in task.assigned_robots:
             self.queued_tasks.append(task)
-
-    def d_graph_update_cb(self, msg):
-        self.logger.critical("Received d-graph-update")
-        payload = msg['payload']
-        d_graph_update = DGraphUpdate.from_payload(payload)
-        self.zero_timepoint = TimeStamp.from_str(d_graph_update.zero_timepoint)
-        dispatchable_graph = STN.from_dict(d_graph_update.dispatchable_graph)
-        if self.dispatchable_graph:
-            self.update_dispatchable_graph(dispatchable_graph)
-        else:
-            self.dispatchable_graph = dispatchable_graph
-
 

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -3,6 +3,7 @@ import logging
 from fmlib.models.tasks import Task
 from ropod.structs.task import TaskStatus as TaskStatusConst
 
+from mrs.exceptions.execution import InconsistentSchedule
 from mrs.scheduling.monitor import ScheduleMonitor
 
 
@@ -20,13 +21,29 @@ class ExecutorInterface:
                                                 allocation_method,
                                                 corrective_measure)
         self.queued_tasks = list()
+        self.scheduled_tasks = list()
+        self.ongoing_task = None
         self.logger = logging.getLogger("mrs.executor.interface.%s" % self.robot_id)
         self.logger.debug("Executor interface initialized %s", self.robot_id)
 
-    def execute(self, task_id):
-        self.logger.debug("Starting execution of task %s", task_id)
-        task = Task.get_task(task_id)
-        task.update_status(TaskStatusConst.ONGOING)
+    def execute(self, task):
+        self.scheduled_tasks.remove(task)
+        self.ongoing_task = task
+        self.logger.debug("Starting execution of task %s", task.task_id)
+
+    def run(self):
+        if self.queued_tasks:
+            task = self.queued_tasks.pop(0)
+            try:
+                scheduled_task = self.schedule_monitor.schedule(task)
+                self.scheduled_tasks.append(scheduled_task)
+            except InconsistentSchedule:
+                pass
+
+        if self.scheduled_tasks and self.ongoing_task is None:
+            for task in self.scheduled_tasks:
+                if task.is_executable():
+                    self.execute(task)
 
     def task_cb(self, msg):
         payload = msg['payload']
@@ -34,4 +51,5 @@ class ExecutorInterface:
         self.logger.debug("Received task %s", task.task_id)
         if self.robot_id in task.assigned_robots:
             self.queued_tasks.append(task)
+
 

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -3,6 +3,8 @@ import logging
 from mrs.exceptions.execution import InconsistentSchedule
 from mrs.exceptions.execution import MissingDispatchableGraph
 from mrs.scheduling.monitor import ScheduleMonitor
+from ropod.structs.task import TaskStatus as TaskStatusConst
+from mrs.execution.archive_task import ArchiveTask
 
 
 class ExecutorInterface:
@@ -15,56 +17,62 @@ class ExecutorInterface:
         self.api = kwargs.get('api')
         self.ccu_store = kwargs.get('ccu_store')
         time_resolution = kwargs.get('time_resolution', 0.5)
-        self.scheduled_tasks = list()
-        self.ongoing_task = None
-        self.finished_tasks = list()
+        self.tasks = list()
+        self.archived_tasks = list()
+        self.task_to_archive = None
         self.schedule_monitor = ScheduleMonitor(robot_id,
                                                 stp_solver,
                                                 allocation_method,
                                                 corrective_measure,
                                                 time_resolution,
-                                                self.ongoing_task,
-                                                self.scheduled_tasks,
-                                                self.finished_tasks)
-        self.queued_tasks = list()
+                                                self.tasks)
         self.logger = logging.getLogger("mrs.executor.interface.%s" % self.robot_id)
         self.logger.debug("Executor interface initialized %s", self.robot_id)
 
     def execute(self, task):
-        self.scheduled_tasks.remove(task)
-        self.ongoing_task = task
         self.logger.debug("Starting execution of task %s", task.task_id)
 
     def task_progress_cb(self):
         # For now, assume that the task's timepoints get assigned their latest time
         # TODO: Receive task progress msgs
-        if self.ongoing_task:
-            pickup_time = self.schedule_monitor.dispatchable_graph.get_time(self.ongoing_task.task_id, 'start', False)
-            self.logger.debug("Task %s, assigning pickup_time %s", self.ongoing_task.task_id, pickup_time)
-            self.schedule_monitor.assign_timepoint(pickup_time, self.ongoing_task.task_id, 'start')
+        for task in self.tasks:
+            if task.status.status == TaskStatusConst.ONGOING:
+                pickup_time = self.schedule_monitor.dispatchable_graph.get_time(task.task_id, 'start', False)
+                self.logger.debug("Task %s, assigning pickup_time %s", task.task_id, pickup_time)
+                self.schedule_monitor.assign_timepoint(pickup_time, task.task_id, 'start')
 
-            delivery_time = self.schedule_monitor.dispatchable_graph.get_time(self.ongoing_task.task_id, 'finish', False)
-            self.logger.debug("Task %s, assigning delivery_time %s", self.ongoing_task.task_id, delivery_time)
-            self.schedule_monitor.assign_timepoint(delivery_time, self.ongoing_task.task_id, 'finish')
+                delivery_time = self.schedule_monitor.dispatchable_graph.get_time(task.task_id, 'finish', False)
+                self.logger.debug("Task %s, assigning delivery_time %s", task.task_id, delivery_time)
+                self.schedule_monitor.assign_timepoint(delivery_time, task.task_id, 'finish')
 
-            self.finished_tasks.append(self.ongoing_task)
-            self.ongoing_task = None
+                self.archive_task(task)
+
+    def archive_task(self, task):
+        self.logger.debug("Deleting task: %s", task.task_id)
+        task.update_status(TaskStatusConst.COMPLETED)
+        self.tasks.remove(task)
+        self.archived_tasks.append(task)
+        node_id = self.schedule_monitor.remove_task(task.task_id)
+        archive_task = ArchiveTask(self.robot_id, task.task_id, node_id)
+        # Provisional hack
+        self.task_to_archive = archive_task
+        archive_task_msg = self.api.create_message(archive_task)
+        self.api.publish(archive_task_msg)
 
     def run(self):
-        if self.queued_tasks:
-            task = self.queued_tasks.pop(0)
-            try:
-                scheduled_task = self.schedule_monitor.schedule(task)
-                self.scheduled_tasks.append(scheduled_task)
-            except MissingDispatchableGraph:
-                pass
-            except InconsistentSchedule:
-                pass
+        for task in self.tasks:
+            if task.status.status == TaskStatusConst.DISPATCHED:
+                try:
+                    scheduled_task = self.schedule_monitor.schedule(task)
+                    scheduled_task.update_status(TaskStatusConst.SCHEDULED)
+                except MissingDispatchableGraph:
+                    pass
+                except InconsistentSchedule:
+                    pass
 
-        if self.scheduled_tasks and self.ongoing_task is None:
-            for task in self.scheduled_tasks:
-                if task.is_executable():
-                    self.execute(task)
+            if task.status.status == TaskStatusConst.SCHEDULED and task.is_executable():
+                task.update_status(TaskStatusConst.ONGOING)
+                self.execute(task)
 
         self.task_progress_cb()
 

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -5,6 +5,7 @@ from ropod.structs.task import TaskStatus as TaskStatusConst
 from mrs.scheduling.monitor import ScheduleMonitor
 import networkx as nx
 from stn.stn import STN
+from ropod.utils.timestamp import TimeStamp
 
 
 class ExecutorInterface:
@@ -22,6 +23,7 @@ class ExecutorInterface:
                                                 corrective_measure)
         self.queued_tasks = list()
         self.dispatchable_graph = None
+        self.zero_timepoint = None
         self.logger = logging.getLogger("mrs.executor.interface.%s" % self.robot_id)
         self.logger.debug("Executor interface initialized %s", self.robot_id)
 
@@ -55,6 +57,7 @@ class ExecutorInterface:
         self.logger.critical("Received d-graph-update")
         payload = msg['payload']
         d_graph_update = DGraphUpdate.from_payload(payload)
+        self.zero_timepoint = TimeStamp.from_str(d_graph_update.zero_timepoint)
         dispatchable_graph = STN.from_dict(d_graph_update.dispatchable_graph)
         if self.dispatchable_graph:
             self.update_dispatchable_graph(dispatchable_graph)

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -4,6 +4,7 @@ from fmlib.models.tasks import Task
 from ropod.structs.task import TaskStatus as TaskStatusConst
 
 from mrs.exceptions.execution import InconsistentSchedule
+from mrs.exceptions.execution import MissingDispatchableGraph
 from mrs.scheduling.monitor import ScheduleMonitor
 
 
@@ -37,6 +38,8 @@ class ExecutorInterface:
             try:
                 scheduled_task = self.schedule_monitor.schedule(task)
                 self.scheduled_tasks.append(scheduled_task)
+            except MissingDispatchableGraph:
+                pass
             except InconsistentSchedule:
                 pass
 
@@ -51,5 +54,6 @@ class ExecutorInterface:
         self.logger.debug("Received task %s", task.task_id)
         if self.robot_id in task.assigned_robots:
             self.queued_tasks.append(task)
+            task.update_status(TaskStatusConst.DISPATCHED)
 
 

--- a/mrs/execution/interface.py
+++ b/mrs/execution/interface.py
@@ -17,10 +17,12 @@ class ExecutorInterface:
         self.robot_id = robot_id
         self.api = kwargs.get('api')
         self.ccu_store = kwargs.get('ccu_store')
+        time_resolution = kwargs.get('time_resolution', 0.5)
         self.schedule_monitor = ScheduleMonitor(robot_id,
                                                 stp_solver,
                                                 allocation_method,
-                                                corrective_measure)
+                                                corrective_measure,
+                                                time_resolution)
         self.queued_tasks = list()
         self.scheduled_tasks = list()
         self.ongoing_task = None

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -38,6 +38,7 @@ class Robot(object):
         try:
             self.api.start()
             while True:
+                self.executor_interface.run()
                 time.sleep(0.5)
         except (KeyboardInterrupt, SystemExit):
             self.logger.info("Terminating %s robot ...", self.robot_id)

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -33,8 +33,8 @@ class Robot(object):
         task = Task.from_payload(payload)
         self.logger.debug("Received task %s", task.task_id)
         if self.robot_id in task.assigned_robots:
-            self.executor_interface.queued_tasks.append(task)
             task.update_status(TaskStatusConst.DISPATCHED)
+            self.executor_interface.tasks.append(task)
             TaskLot.freeze_task(task.task_id)
 
     def run(self):
@@ -42,6 +42,12 @@ class Robot(object):
             self.api.start()
             while True:
                 self.executor_interface.run()
+                # Provisional hack
+                if self.executor_interface.task_to_archive:
+                    self.bidder.archive_task(self.executor_interface.task_to_archive.robot_id,
+                                             self.executor_interface.task_to_archive.task_id,
+                                             self.executor_interface.task_to_archive.node_id)
+                    self.executor_interface.task_to_archive = None
                 time.sleep(0.5)
         except (KeyboardInterrupt, SystemExit):
             self.logger.info("Terminating %s robot ...", self.robot_id)

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -1,6 +1,7 @@
 import time
 from fmlib.models.tasks import Task
 from ropod.structs.task import TaskStatus as TaskStatusConst
+from mrs.db.models.task import TaskLot
 
 
 class Robot(object):
@@ -30,9 +31,11 @@ class Robot(object):
     def task_cb(self, msg):
         payload = msg['payload']
         task = Task.from_payload(payload)
-        self.logger.critical("Received task %s", task.task_id)
+        self.logger.debug("Received task %s", task.task_id)
         if self.robot_id in task.assigned_robots:
+            self.executor_interface.queued_tasks.append(task)
             task.update_status(TaskStatusConst.DISPATCHED)
+            TaskLot.freeze_task(task.task_id)
 
     def run(self):
         try:

--- a/mrs/scheduling/monitor.py
+++ b/mrs/scheduling/monitor.py
@@ -7,6 +7,7 @@ from stn.stn import STN
 from mrs.dispatching.d_graph_update import DGraphUpdate
 from mrs.scheduling.scheduler import Scheduler
 from mrs.exceptions.execution import InconsistentSchedule
+from mrs.exceptions.execution import MissingDispatchableGraph
 
 
 class ScheduleMonitor:
@@ -52,11 +53,13 @@ class ScheduleMonitor:
     def schedule(self, task):
         try:
             if not self.dispatchable_graph:
-                self.logger.warning("The schedule monitor does not have a dispatchable graph")
-                return
+                self.logger.error("The schedule monitor does not have a dispatchable graph")
+                raise MissingDispatchableGraph(self.robot_id)
+
             scheduled_task, dispatchable_task = self.scheduler.schedule(task, self.dispatchable_graph, self.zero_timepoint)
             self.dispatchable_graph = dispatchable_task
             return scheduled_task
+
         except InconsistentSchedule as e:
             # TODO: Trigger corrective measure
             raise InconsistentSchedule(e.relative_time)

--- a/mrs/scheduling/monitor.py
+++ b/mrs/scheduling/monitor.py
@@ -23,7 +23,8 @@ class ScheduleMonitor:
     def __init__(self, robot_id,
                  stp_solver,
                  allocation_method,
-                 corrective_measure):
+                 corrective_measure,
+                 time_resolution):
         """ Includes methods to monitor the schedule of a robot's allocated tasks
 
        Args:
@@ -36,7 +37,7 @@ class ScheduleMonitor:
         self.robot_id = robot_id
         self.stp_solver = stp_solver
         self.corrective_measure = self.get_corrective_measure(allocation_method, corrective_measure)
-        self.scheduler = Scheduler(self.stp_solver, self.robot_id)
+        self.scheduler = Scheduler(self.stp_solver, self.robot_id, time_resolution)
         self.dispatchable_graph = None
         self.zero_timepoint = None
         self.logger = logging.getLogger('mrs.schedule.monitor.%s' % self.robot_id)
@@ -58,6 +59,8 @@ class ScheduleMonitor:
 
             scheduled_task, dispatchable_task = self.scheduler.schedule(task, self.dispatchable_graph, self.zero_timepoint)
             self.dispatchable_graph = dispatchable_task
+            self.logger.info("Task %s scheduled to start at %s", task.task_id, task.start_time)
+            self.logger.debug("Dispatchable graph %s", self.dispatchable_graph)
             return scheduled_task
 
         except InconsistentSchedule as e:

--- a/mrs/scheduling/monitor.py
+++ b/mrs/scheduling/monitor.py
@@ -62,7 +62,7 @@ class ScheduleMonitor:
 
         except InconsistentSchedule as e:
             # TODO: Trigger corrective measure
-            raise InconsistentSchedule(e.relative_time)
+            raise InconsistentSchedule(e.earliest_time, e.latest_time)
 
     def update_dispatchable_graph(self, dispatchable_graph):
         current_task_ids = self.dispatchable_graph.get_tasks()

--- a/mrs/scheduling/monitor.py
+++ b/mrs/scheduling/monitor.py
@@ -6,6 +6,7 @@ from stn.stn import STN
 
 from mrs.dispatching.d_graph_update import DGraphUpdate
 from mrs.scheduling.scheduler import Scheduler
+from mrs.exceptions.execution import InconsistentSchedule
 
 
 class ScheduleMonitor:
@@ -47,6 +48,18 @@ class ScheduleMonitor:
             raise ValueError(corrective_measure)
 
         return corrective_measure
+
+    def schedule(self, task):
+        try:
+            if not self.dispatchable_graph:
+                self.logger.warning("The schedule monitor does not have a dispatchable graph")
+                return
+            scheduled_task, dispatchable_task = self.scheduler.schedule(task, self.dispatchable_graph, self.zero_timepoint)
+            self.dispatchable_graph = dispatchable_task
+            return scheduled_task
+        except InconsistentSchedule as e:
+            # TODO: Trigger corrective measure
+            raise InconsistentSchedule(e.relative_time)
 
     def update_dispatchable_graph(self, dispatchable_graph):
         current_task_ids = self.dispatchable_graph.get_tasks()

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -38,7 +38,7 @@ class Scheduler(object):
 
         self.logger.warning("Task %s could not be scheduled between %s and %s", task.task_id,
                             earliest_start_time, latest_start_time)
-        raise InconsistentSchedule(latest_start_time)
+        raise InconsistentSchedule(earliest_start_time, latest_start_time)
 
 
 

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -1,4 +1,8 @@
 import logging
+import numpy as np
+from stn.methods.fpc import get_minimal_network
+from mrs.exceptions.execution import InconsistentSchedule
+from datetime import timedelta
 
 
 class Scheduler(object):
@@ -9,3 +13,32 @@ class Scheduler(object):
         self.is_scheduling = False
 
         self.logger.debug("Scheduler initialized %s", self.robot_id)
+
+    def assign_timepoint(self, assigned_time, dispatchable_graph, task_id, node_type):
+        minimal_network = get_minimal_network(dispatchable_graph)
+
+        if minimal_network:
+            minimal_network.assign_timepoint(assigned_time, task_id, node_type)
+            if self.stp_solver.is_consistent(minimal_network):
+                dispatchable_graph.assign_timepoint(assigned_time, task_id, node_type)
+                return dispatchable_graph
+        return None
+
+    def schedule(self, task, dispatchable_graph, zero_timepoint):
+        earliest_start_time = dispatchable_graph.get_time(task.task_id, lower_bound=True)
+        latest_start_time = dispatchable_graph.get_time(task.task_id, lower_bound=False)
+        # TODO: Define resolution
+        start_times = np.arange(earliest_start_time, latest_start_time, 0.5).tolist()
+
+        for start_time in start_times:
+            dispatchable_graph = self.assign_timepoint(start_time, dispatchable_graph, task.task_id, "navigation")
+            if dispatchable_graph:
+                task.start_time = (zero_timepoint + timedelta(minutes=start_time)).to_datetime()
+                return task, dispatchable_graph
+
+        self.logger.warning("Task %s could not be scheduled between %s and %s", task.task_id,
+                            earliest_start_time, latest_start_time)
+        raise InconsistentSchedule(latest_start_time)
+
+
+

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -1,8 +1,10 @@
 import logging
+from datetime import timedelta
+
 import numpy as np
 from stn.methods.fpc import get_minimal_network
+
 from mrs.exceptions.execution import InconsistentSchedule
-from datetime import timedelta
 
 
 class Scheduler(object):
@@ -25,10 +27,17 @@ class Scheduler(object):
                 return dispatchable_graph
         return None
 
+    def get_times(self, earliest_time, latest_time):
+        start_times = np.arange(earliest_time, latest_time, self.time_resolution).tolist()
+        if not start_times:
+            start_times = [earliest_time, latest_time]
+        return start_times
+
     def schedule(self, task, dispatchable_graph, zero_timepoint):
+        self.logger.debug("Scheduling task: %s", task.task_id)
         earliest_start_time = dispatchable_graph.get_time(task.task_id, lower_bound=True)
         latest_start_time = dispatchable_graph.get_time(task.task_id, lower_bound=False)
-        start_times = np.arange(earliest_start_time, latest_start_time, self.time_resolution).tolist()
+        start_times = self.get_times(earliest_start_time, latest_start_time)
 
         for start_time in start_times:
             dispatchable_graph = self.assign_timepoint(start_time, dispatchable_graph, task.task_id, "navigation")

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -6,9 +6,10 @@ from datetime import timedelta
 
 
 class Scheduler(object):
-    def __init__(self, stp_solver, robot_id):
+    def __init__(self, stp_solver, robot_id, time_resolution):
         self.stp_solver = stp_solver
         self.robot_id = robot_id
+        self.time_resolution = time_resolution
         self.logger = logging.getLogger("mrs.scheduler")
         self.is_scheduling = False
 
@@ -27,8 +28,7 @@ class Scheduler(object):
     def schedule(self, task, dispatchable_graph, zero_timepoint):
         earliest_start_time = dispatchable_graph.get_time(task.task_id, lower_bound=True)
         latest_start_time = dispatchable_graph.get_time(task.task_id, lower_bound=False)
-        # TODO: Define resolution
-        start_times = np.arange(earliest_start_time, latest_start_time, 0.5).tolist()
+        start_times = np.arange(earliest_start_time, latest_start_time, self.time_resolution).tolist()
 
         for start_time in start_times:
             dispatchable_graph = self.assign_timepoint(start_time, dispatchable_graph, task.task_id, "navigation")

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -40,6 +40,13 @@ class TimetableManager(object):
         for robot_id, timetable in self.timetables.items():
             timetable.fetch()
 
+    def get_n_allocated_tasks(self):
+        self.fetch_timetables()
+        n_allocated_tasks = dict()
+        for robot_id, timetable in self.timetables.items():
+            n_allocated_tasks[robot_id] = len(timetable.stn.get_tasks())
+        return n_allocated_tasks
+
     def update_timetable(self, robot_id, insertion_point, temporal_metric, task_lot):
         timetable = self.timetables.get(robot_id)
         timetable.fetch()

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -199,8 +199,7 @@ class Timetable(object):
     def remove_task(self, position=1):
         self.stn.remove_task(position)
         self.dispatchable_graph.remove_task(position)
-        # Reset schedule (there is only one task in the schedule)
-        self.schedule = None
+        self.store()
 
     def get_scheduled_task_id(self):
         if self.schedule is None:

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -9,9 +9,8 @@ from ropod.utils.timestamp import TimeStamp
 from stn.exceptions.stp import NoSTPSolution
 from stn.task import STNTask
 
+from mrs.db.models.task import TaskLot
 from mrs.db.models.timetable import Timetable as TimetableMongo
-from mrs.exceptions.execution import InconsistentSchedule
-from stn.methods.fpc import get_minimal_network
 
 logger = logging.getLogger("mrs.timetable")
 
@@ -55,13 +54,72 @@ class Timetable(object):
         task = self.to_stn_task(task_lot, insertion_point)
         stn = copy.deepcopy(self.stn)
         stn.add_task(task, insertion_point)
-
         try:
             dispatchable_graph = self.stp.solve(stn)
             return stn, dispatchable_graph
 
         except NoSTPSolution:
             raise NoSTPSolution()
+
+    def get_hard_constraints(self, task_lot, insertion_point):
+        start_timepoint = task_lot.constraints.timepoint_constraints[0]
+
+        if insertion_point == 1:
+            # TODO: Get navigation constraints using duration travel info:
+            #  [mu - 2sd, mu + 2sd] from current pose to start_pose of new task
+            earliest_navigation_start = start_timepoint.earliest_time - timedelta(minutes=0.5)
+            navigation_timepoint = \
+                TimepointConstraints(earliest_time=earliest_navigation_start,
+                                     latest_time=earliest_navigation_start)
+        else:
+            previous_task_id = self.dispatchable_graph.get_task_id(insertion_point-1)
+            previous_task = TaskLot.get_task(previous_task_id)
+
+            if previous_task.frozen:
+                r_latest_finish_time = self.dispatchable_graph.get_time(previous_task_id, "finish", False)
+                earliest_navigation_start = self.zero_timepoint + timedelta(minutes=r_latest_finish_time)
+                navigation_timepoint = TimepointConstraints(earliest_time=earliest_navigation_start.to_datetime(),
+                                                            latest_time=earliest_navigation_start.to_datetime())
+            else:
+                navigation_timepoint = TimepointConstraints(earliest_time=self.zero_timepoint.to_datetime(),
+                                                            latest_time=self.zero_timepoint.to_datetime())
+
+        return navigation_timepoint, start_timepoint
+
+    def get_soft_constraints(self, task_lot, insertion_point):
+        if insertion_point == 1:
+            # Try to start task as soon as possible
+            start_time = datetime.now() + timedelta(minutes=1)
+            start_timepoint = TimepointConstraints(earliest_time=start_time)
+
+            # TODO: Get start constraints using duration travel info:
+            #  [mu - 2sd, mu + 2sd] from current pose to start_pose of new task
+            earliest_navigation_start = start_timepoint.earliest_time - timedelta(minutes=0.5)
+            navigation_timepoint = \
+                TimepointConstraints(earliest_time=earliest_navigation_start,
+                                     latest_time=earliest_navigation_start)
+        else:
+            previous_task_id = self.dispatchable_graph.get_task_id(insertion_point-1)
+            previous_task = TaskLot.get_task(previous_task_id)
+            r_latest_finish_time = self.dispatchable_graph.get_time(previous_task_id, "finish", False)
+
+            latest_finish_time = self.zero_timepoint + timedelta(minutes=r_latest_finish_time)
+
+            if previous_task.frozen:
+                navigation_timepoint = TimepointConstraints(earliest_time=latest_finish_time.to_datetime(),
+                                                            latest_time=latest_finish_time.to_datetime())
+            else:
+                navigation_timepoint = TimepointConstraints(earliest_time=self.zero_timepoint.to_datetime(),
+                                                            latest_time=self.zero_timepoint.to_datetime())
+
+            # TODO: Get start constraints using duration travel info:
+            #  [mu - 2sd, mu + 2sd] from finish_pose of last task to start_pose of new task
+            earliest_time = latest_finish_time + timedelta(minutes=5)
+            latest_time = earliest_time + timedelta(minutes=6)
+            start_timepoint = TimepointConstraints(earliest_time=earliest_time.to_datetime(),
+                                                   latest_time=latest_time.to_datetime())
+
+        return navigation_timepoint, start_timepoint
 
     def to_stn_task(self, task_lot, insertion_point):
         """ Converts a task to an stn task
@@ -70,38 +128,21 @@ class Timetable(object):
             task_lot (obj): task_lot object to be converted
             insertion_point(int): position in the stn in which the task will be insterted
         """
-        if not task_lot.constraints.hard:
-            # Get latest finish time of task in previous position
-            if insertion_point > 1:
-                previous_task_id = self.dispatchable_graph.get_task_id(insertion_point-1)
-                r_latest_finish_time = self.dispatchable_graph.get_time(previous_task_id, "finish", False)
-
-                latest_finish_time = self.zero_timepoint + timedelta(minutes=r_latest_finish_time)
-                earliest_time = latest_finish_time + timedelta(minutes=5)
-                latest_time = earliest_time + timedelta(minutes=5)
-
-                start_timepoint_constraints = TimepointConstraints(earliest_time=earliest_time.to_datetime(),
-                                                                   latest_time=latest_time.to_datetime())
-            else:
-
-                start_time = datetime.now() + timedelta(minutes=1)
-                start_timepoint_constraints = TimepointConstraints(earliest_time=start_time,
-                                                                   latest_time=start_time)
+        if task_lot.constraints.hard:
+            navigation_timepoint, start_timepoint = self.get_hard_constraints(task_lot, insertion_point)
         else:
-            start_timepoint_constraints = task_lot.constraints.timepoint_constraints[0]
+            navigation_timepoint, start_timepoint = self.get_soft_constraints(task_lot, insertion_point)
 
-        r_earliest_start_time, r_latest_start_time = TimepointConstraints.relative_to_ztp(start_timepoint_constraints,
+        r_earliest_start_time, r_latest_start_time = TimepointConstraints.relative_to_ztp(start_timepoint,
                                                                                           self.zero_timepoint)
-        r_earliest_navigation_start = r_earliest_start_time - 0.5
-
+        r_earliest_navigation_time, r_latest_navigation_time = TimepointConstraints.relative_to_ztp(navigation_timepoint,
+                                                                                                    self.zero_timepoint)
         stn_task = STNTask(task_lot.task.task_id,
-                           r_earliest_navigation_start,
+                           r_earliest_navigation_time,
                            r_earliest_start_time,
                            r_latest_start_time,
                            task_lot.start_location,
-                           task_lot.finish_location,
-                           hard_constraints=task_lot.constraints.hard)
-
+                           task_lot.finish_location)
         return stn_task
 
     def get_tasks(self):
@@ -181,20 +222,6 @@ class Timetable(object):
             self.schedule = self.dispatchable_graph.get_subgraph(node_ids)
         else:
             logger.error("The dispatchable graph is empty")
-
-    def assign_timepoint(self, r_time, task_id, node_type):
-        # TODO: Use sub-stn to get minimal_network
-        minimal_network = get_minimal_network(self.stn)
-
-        if minimal_network:
-            minimal_network.assign_timepoint(r_time, task_id, node_type)
-            if self.stp.is_consistent(minimal_network):
-                self.stn.assign_timepoint(r_time, task_id, node_type)
-                self.dispatchable_graph.assign_timepoint(r_time, task_id, node_type)
-                self.schedule = self.dispatchable_graph.get_subgraph(n_tasks=1)
-                self.store()
-        else:
-            raise InconsistentSchedule(r_time)
 
     def to_dict(self):
         timetable_dict = dict()


### PR DESCRIPTION
**d_graph_update**
-  Add zero_timepoint to msg
- The robot schedule_monitor receives the d_graph_update, not the executor_interface

**exceptions**
- Add MissingDispatchableGraph
- InconsistentSchedule receives the earliest and latest times that tried to be assigned to the timepoint

**config**
- Add time_resolution = 0.5 min. The time resolution is the size of the steps between the earliest and latest times used for scheduling a task

**auctioneer**
- Fix allocate() to add all tasks to self.tasks_to_allocate
- Add method to archive tasks
- Receive archive-task msg, delete task from db and dispatchable graph

**task_lot**
- Add method to freeze task 

**dispatching/schedule_monitor**
- Add logger 

**executor_interface**:
- For now, assume that the tasks' timepoints get assigned their latest time

**robot/schedule_monitor**
- Update task in the dispatch graph if the task is new of it is neither scheduled nor ongoing

**dispatcher**
- Freezes task before dispatching it
- Send a d-graph-update after a task has been deleted

**robot**
- Freezes task after receiving it from the dispatcher

**scheduler**
- Add method to get times before the earliest and latest time, given a time resolution

**timetable**
-  Add methods to get task navigation and start constraints (specific to SREA)
- Store timetable in mongo after removing a task

**round**
- Add n_allocated_tasks to check if the timetables changed while the round was open

**timetable/manager**
- Add method to get n_allocated_tasks per robot_id

**executor_interface**
- Send archive-task msg, delete task from db and dispatchable graph

**bidder**
- Receive archive-task msg, delete task from db and dispatchable graph

Closes #52 
Requires: https://git.ropod.org/ropod/ccu/fmlib/merge_requests/11

