### PR TITLE
Introduce delay by adding n_standard_dev to sampled value

### DIFF
--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -39,6 +39,7 @@ robot:
     corrective_measure: re-allocate
     time_resolution: 0.5 # minutes
     max_seed: 2147483647
+    delay_n_standard_dev: 1
 
 robot_api:
   version: 0.1.0

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -66,15 +66,21 @@ class InterTimepointConstraint(EmbeddedMongoModel):
     mean = fields.FloatField()
     variance = fields.FloatField()
 
+    @property
+    def standard_dev(self):
+        return round(self.variance ** 0.5, 3)
+
     def __str__(self):
         to_print = ""
         to_print += "{}: N({}, {})".format(self.name, self.mean, self.variance ** 0.5)
         return to_print
 
     def sample(self, random_state):
-        standard_dev = round(self.variance ** 0.5, 3)
-        sample = norm_sample(self.mean, standard_dev, random_state)
+        sample = norm_sample(self.mean, self.standard_dev, random_state)
         return round(sample)
+
+    def get_duration(self, random_state, delay_n_standard_dev):
+        return self.sample(random_state) + delay_n_standard_dev*self.standard_dev
 
     @classmethod
     def from_payload(cls, payload):


### PR DESCRIPTION
- config: Add `delay_n_standard_dev`, defaults to zero.
- task: Add property to compute `standard_dev`
- task: Add `delay_n_standard_dev*self.standard_dev` to inter_timepoint_constraint's durations.