### PR TITLE
Update task plan to include task and pre-task actions

### DIFF
--- a/mrs/allocation/bidding_rule.py
+++ b/mrs/allocation/bidding_rule.py
@@ -7,7 +7,7 @@ class BiddingRule(object):
     def __init__(self, temporal_criterion):
         self.temporal_criterion = temporal_criterion
 
-    def compute_bid(self, robot_id, round_id, task, insertion_point, timetable, travel_time):
+    def compute_bid(self, robot_id, round_id, task, insertion_point, timetable, pre_task_action):
         try:
             stn, dispatchable_graph = timetable.solve_stp(task, insertion_point)
             dispatchable_graph.compute_temporal_metric(self.temporal_criterion)
@@ -18,7 +18,7 @@ class BiddingRule(object):
                           round_id,
                           insertion_point,
                           Metrics(dispatchable_graph.temporal_metric, dispatchable_graph.risk_metric),
-                          travel_time)
+                          pre_task_action)
             else:
                 pickup_constraint = task.get_timepoint_constraint("pickup")
                 temporal_metric = abs(pickup_constraint.earliest_time - task.request.earliest_pickup_time).total_seconds()
@@ -30,7 +30,7 @@ class BiddingRule(object):
                               round_id,
                               insertion_point,
                               Metrics(temporal_metric, risk_metric),
-                              travel_time,
+                              pre_task_action,
                               alternative_start_time)
 
             bid.stn = stn

--- a/mrs/db/models/actions.py
+++ b/mrs/db/models/actions.py
@@ -1,0 +1,20 @@
+from fmlib.models.actions import GoTo as GoToBase
+from pymodm import fields
+from mrs.db.models.task import InterTimepointConstraint
+from fmlib.utils.messages import Document
+
+
+class GoTo(GoToBase):
+    estimated_duration = fields.EmbeddedDocumentField(InterTimepointConstraint)
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_payload(payload)
+        document["estimated_duration"] = InterTimepointConstraint.from_payload(document.pop("estimated_duration"))
+        return cls.from_document(document)
+
+    def to_dict(self):
+        dict_repr = self.to_son().to_dict()
+        dict_repr.pop('_cls')
+        dict_repr["estimated_duration"] = self.estimated_duration.to_dict()
+        return dict_repr

--- a/mrs/messages/bid.py
+++ b/mrs/messages/bid.py
@@ -1,4 +1,4 @@
-from mrs.db.models.task import InterTimepointConstraint
+from mrs.db.models.actions import GoTo
 from mrs.utils.as_dict import AsDictMixin
 
 
@@ -59,10 +59,10 @@ class NoBid(BidBase):
 
 
 class Bid(BidBase):
-    def __init__(self, task_id, robot_id, round_id, insertion_point, metrics, travel_time):
+    def __init__(self, task_id, robot_id, round_id, insertion_point, metrics, pre_task_action):
         self.insertion_point = insertion_point
         self.metrics = metrics
-        self.travel_time = travel_time
+        self.pre_task_action = pre_task_action
         self._stn = None
         self._dispatchable_graph = None
         super().__init__(task_id, robot_id, round_id)
@@ -106,13 +106,13 @@ class Bid(BidBase):
     def to_attrs(cls, dict_repr):
         attrs = super().to_attrs(dict_repr)
         attrs.update(metrics=Metrics.from_dict(dict_repr.get("metrics")))
-        attrs.update(travel_time=InterTimepointConstraint.from_payload(dict_repr.get("travel_time")))
+        attrs.update(pre_task_action=GoTo.from_payload(dict_repr.get("pre_task_action")))
         return attrs
 
 
 class SoftBid(Bid):
-    def __init__(self, task_id, robot_id, round_id, insertion_point, metrics, travel_time, alternative_start_time):
-        super().__init__(task_id, robot_id, round_id, insertion_point, metrics, travel_time)
+    def __init__(self, task_id, robot_id, round_id, insertion_point, metrics, pre_task_action, alternative_start_time):
+        super().__init__(task_id, robot_id, round_id, insertion_point, metrics, pre_task_action)
         self.alternative_start_time = alternative_start_time
 
     def __str__(self):

--- a/mrs/scheduling/scheduler.py
+++ b/mrs/scheduling/scheduler.py
@@ -29,8 +29,10 @@ class Scheduler(object):
         return None
 
     def get_times(self, earliest_time, latest_time):
-        start_times = np.arange(earliest_time, latest_time, self.time_resolution).tolist()
-        if not start_times:
+        start_times = list(np.arange(earliest_time, latest_time + self.time_resolution, self.time_resolution))
+        if start_times[-1] > latest_time:
+            start_times.pop()
+        if len(start_times) < 2:
             start_times = [earliest_time, latest_time]
         return start_times
 

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -33,7 +33,10 @@ class TimetableManager(object):
             timetable.update_zero_timepoint(time_)
 
     def get_timetable(self, robot_id):
-        return self.timetables.get(robot_id)
+        timetable = self.timetables.get(robot_id)
+        timetable.fetch()
+        self.timetables.update({robot_id: timetable})
+        return timetable
 
     def register_robot(self, robot_id):
         self.logger.debug("Registering robot %s", robot_id)

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -172,7 +172,7 @@ class Timetable(object):
         else:
             raise TaskNotFound(position)
 
-    def get_earliest_tasks(self, n_tasks=2):
+    def get_earliest_tasks(self, n_tasks=1):
         """ Returns a list of the earliest n_tasks in the timetable
 
         :return: list of tasks


### PR DESCRIPTION
The task_plan consists of two GoTo actions:
-  PICKUP-TO-DELIVERY (task action)
-  ROBOT-TO-PICKUP (pre-task action)

PICKUP-TO-DELIVERY is computed before allocating the task
The bidder computes the ROBOT-TO-PICKUP action and includes it in its bid
After an allocation is completed, the CCU adds both actions to the plan and stores the plan in the ccu_store

- timetable/get_earliest_tasks: Update default n_tasks to 1
- timetable/manager: Fetch and update timetable in get_timetable 
- scheduler: Fix get_times to include the upper bound