### PR TITLE
Fix pre-task-action and constraints of task after allocated task

### DIFF
--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -40,8 +40,9 @@ class Auctioneer(SimulatorInterface):
         self.logger.debug("Auctioneer started")
 
         self.tasks_to_allocate = dict()
+        self.allocated_tasks = dict()
         self.allocations = list()
-        self.pre_task_actions = dict()
+        self.pre_task_actions = list()
         self.winning_bid = None
         self.deleted_a_task = list()
         self.waiting_for_user_confirmation = list()
@@ -99,17 +100,25 @@ class Auctioneer(SimulatorInterface):
         self.winning_bid = bid
         self.announce_winner(bid.task_id, bid.robot_id)
 
-    def process_allocation(self):
-        task = self.tasks_to_allocate.pop(self.winning_bid.task_id)
-
+    def process_allocation(self, allocation_info):
         try:
-            travel_time = self.winning_bid.pre_task_action.estimated_duration
-            task.update_inter_timepoint_constraint(**travel_time.to_dict())
-            self.pre_task_actions[self.winning_bid.task_id] = self.winning_bid.pre_task_action
+            for action in allocation_info.pre_task_actions:
+                travel_time = action.estimated_duration
+                task = self.tasks_to_allocate.get(action.task_id) \
+                    if self.tasks_to_allocate.get(action.task_id) is not None \
+                    else self.allocated_tasks.get(action.task_id)
+
+                self.logger.debug("Updating travel time of task %s: ", task.task_id)
+                task.update_inter_timepoint_constraint(**travel_time.to_dict())
+                self.pre_task_actions.append(action)
+
+            task = self.tasks_to_allocate.pop(self.winning_bid.task_id)
+            self.allocated_tasks[task.task_id] = task
 
             self.timetable_manager.update_timetable(self.winning_bid.robot_id,
-                                                    self.winning_bid.insertion_point,
-                                                    self.winning_bid.metrics.temporal, task)
+                                                    allocation_info,
+                                                    self.winning_bid.metrics.temporal,
+                                                    task)
 
             allocation = (self.winning_bid.task_id, [self.winning_bid.robot_id])
             self.logger.debug("Allocation: %s", allocation)
@@ -124,7 +133,6 @@ class Auctioneer(SimulatorInterface):
             self.logger.warning("The allocation of task %s to robot %s is inconsistent. Aborting allocation."
                                 "Task %s will be included in next allocation round", e.task_id, e.robot_id, e.task_id)
             # TODO: Send msg to delete last allocation
-            self.tasks_to_allocate[task.task_id] = task
             self.round.finish()
 
     def allocate(self, tasks):
@@ -195,7 +203,7 @@ class Auctioneer(SimulatorInterface):
 
         if task_contract_ack.accept and task_contract_ack.robot_id not in self.deleted_a_task:
             self.logger.debug("Concluding allocation of task %s", task_contract_ack.task_id)
-            self.process_allocation()
+            self.process_allocation(task_contract_ack.allocation_info)
         elif task_contract_ack.accept and task_contract_ack.robot_id in self.deleted_a_task:
             # TODO: Send msg to delete last allocation
             self.logger.warning("Round %s has to be repeated. Invalidating previous contract", self.round.id)
@@ -217,6 +225,7 @@ class Auctioneer(SimulatorInterface):
         self.logger.debug("Deleting task %s", task.task_id)
         timetable = self.timetable_manager.get_timetable(task.assigned_robots[0])
         timetable.remove_task(task.task_id)
+        self.allocated_tasks.pop(task.task_id)
         self.deleted_a_task.append(task.assigned_robots[0])
         self.logger.debug("STN robot %s: %s", task.assigned_robots[0], timetable.stn)
         self.logger.debug("Dispatchable graph robot %s: %s", task.assigned_robots[0], timetable.dispatchable_graph)

--- a/mrs/allocation/bidder.py
+++ b/mrs/allocation/bidder.py
@@ -162,7 +162,7 @@ class Bidder:
                 pre_task_actions.append(self.get_pre_task_action(next_task, prev_location))
 
                 stn_task = self.timetable.update_stn_task(next_task, insertion_point+1)
-                self.timetable.stn.update_task(stn_task)
+                self.timetable.update_task(stn_task)
                 stn_tasks.append(stn_task)
             except TaskNotFound as e:
                 pass

--- a/mrs/allocation/bidding_rule.py
+++ b/mrs/allocation/bidding_rule.py
@@ -4,21 +4,20 @@ from mrs.messages.bid import Bid, SoftBid, Metrics
 
 
 class BiddingRule(object):
-    def __init__(self, temporal_criterion):
+    def __init__(self, temporal_criterion, timetable):
         self.temporal_criterion = temporal_criterion
+        self.timetable = timetable
 
-    def compute_bid(self, robot_id, round_id, task, insertion_point, timetable, pre_task_action):
+    def compute_bid(self, stn, robot_id, round_id, task, allocation_info):
         try:
-            stn, dispatchable_graph = timetable.solve_stp(task, insertion_point)
+            dispatchable_graph = self.timetable.compute_dispatchable_graph(stn)
             dispatchable_graph.compute_temporal_metric(self.temporal_criterion)
 
             if task.constraints.hard:
                 bid = Bid(task.task_id,
                           robot_id,
                           round_id,
-                          insertion_point,
-                          Metrics(dispatchable_graph.temporal_metric, dispatchable_graph.risk_metric),
-                          pre_task_action)
+                          Metrics(dispatchable_graph.temporal_metric, dispatchable_graph.risk_metric))
             else:
                 pickup_constraint = task.get_timepoint_constraint("pickup")
                 temporal_metric = abs(pickup_constraint.earliest_time - task.request.earliest_pickup_time).total_seconds()
@@ -28,16 +27,14 @@ class BiddingRule(object):
                 bid = SoftBid(task.task_id,
                               robot_id,
                               round_id,
-                              insertion_point,
                               Metrics(temporal_metric, risk_metric),
-                              pre_task_action,
                               alternative_start_time)
 
-            bid.stn = stn
-            bid.dispatchable_graph = dispatchable_graph
+            bid.set_allocation_info(allocation_info)
+            bid.set_stn(stn)
+            bid.set_dispatchable_graph(dispatchable_graph)
 
             return bid
 
         except NoSTPSolution:
             raise NoSTPSolution()
-

--- a/mrs/db/models/actions.py
+++ b/mrs/db/models/actions.py
@@ -5,6 +5,7 @@ from fmlib.utils.messages import Document
 
 
 class GoTo(GoToBase):
+    task_id = fields.UUIDField()
     estimated_duration = fields.EmbeddedDocumentField(InterTimepointConstraint)
 
     def get_node_names(self):

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -133,11 +133,9 @@ class Task(BaseTask):
         self.constraints.hard = False
         self.save()
 
-    @classmethod
-    def freeze_task(cls, task_id):
-        task = cls.get_task(task_id)
-        task.frozen = True
-        task.save()
+    def freeze(self):
+        self.frozen = True
+        self.save()
 
     def mark_as_delayed(self):
         self.status.delayed = True

--- a/mrs/dispatching/dispatcher.py
+++ b/mrs/dispatching/dispatcher.py
@@ -57,7 +57,7 @@ class Dispatcher(object):
             if task and task.status.status == TaskStatusConst.PLANNED:
                 start_time = timetable.get_start_time(task.task_id)
                 if self.schedule_monitor.is_schedulable(start_time):
-                    Task.freeze_task(task.task_id)
+                    task.freeze()
                     self.dispatch_task(task, robot_id)
 
     def dispatch_task(self, task, robot_id):

--- a/mrs/messages/bid.py
+++ b/mrs/messages/bid.py
@@ -1,4 +1,3 @@
-from mrs.db.models.actions import GoTo
 from mrs.utils.as_dict import AsDictMixin
 
 
@@ -59,12 +58,9 @@ class NoBid(BidBase):
 
 
 class Bid(BidBase):
-    def __init__(self, task_id, robot_id, round_id, insertion_point, metrics, pre_task_action):
-        self.insertion_point = insertion_point
+    def __init__(self, task_id, robot_id, round_id, metrics):
         self.metrics = metrics
-        self.pre_task_action = pre_task_action
-        self._stn = None
-        self._dispatchable_graph = None
+        self._allocation_info = None
         super().__init__(task_id, robot_id, round_id)
 
     def __str__(self):
@@ -82,21 +78,17 @@ class Bid(BidBase):
             return False
         return self.metrics == other.metrics
 
-    @property
-    def stn(self):
-        return self._stn
+    def set_stn(self, stn):
+        self._allocation_info.stn = stn
 
-    @stn.setter
-    def stn(self, stn):
-        self._stn = stn
+    def set_dispatchable_graph(self, dispatchable_graph):
+        self._allocation_info.dispatchable_graph = dispatchable_graph
 
-    @property
-    def dispatchable_graph(self):
-        return self._dispatchable_graph
+    def get_allocation_info(self):
+        return self._allocation_info
 
-    @dispatchable_graph.setter
-    def dispatchable_graph(self, dispatchable_graph):
-        self._dispatchable_graph = dispatchable_graph
+    def set_allocation_info(self, allocation_info):
+        self._allocation_info = allocation_info
 
     @property
     def meta_model(self):
@@ -106,13 +98,12 @@ class Bid(BidBase):
     def to_attrs(cls, dict_repr):
         attrs = super().to_attrs(dict_repr)
         attrs.update(metrics=Metrics.from_dict(dict_repr.get("metrics")))
-        attrs.update(pre_task_action=GoTo.from_payload(dict_repr.get("pre_task_action")))
         return attrs
 
 
 class SoftBid(Bid):
-    def __init__(self, task_id, robot_id, round_id, insertion_point, metrics, pre_task_action, alternative_start_time):
-        super().__init__(task_id, robot_id, round_id, insertion_point, metrics, pre_task_action)
+    def __init__(self, task_id, robot_id, round_id, metrics, alternative_start_time):
+        super().__init__(task_id, robot_id, round_id, metrics)
         self.alternative_start_time = alternative_start_time
 
     def __str__(self):

--- a/mrs/messages/dispatch_queue_update.py
+++ b/mrs/messages/dispatch_queue_update.py
@@ -52,8 +52,8 @@ class DispatchQueueUpdate(AsDictMixin):
             merged_graph.add_edges_from(task_graph.edges(data=True))
 
         for i in merged_graph.nodes():
-            if i != 0 and previous_graph.has_node(i + 1) and not previous_graph.has_edge(i, i + 1):
-                previous_graph.add_constraint(i, i + 1)
+            if i != 0 and merged_graph.has_node(i+1) and not merged_graph.has_edge(i, i + 1):
+                merged_graph.add_constraint(i, i + 1)
 
         return merged_graph
 

--- a/mrs/messages/task_contract.py
+++ b/mrs/messages/task_contract.py
@@ -1,3 +1,6 @@
+from stn.task import Task as STNTask
+
+from mrs.db.models.actions import GoTo
 from mrs.utils.as_dict import AsDictMixin
 
 
@@ -11,12 +14,68 @@ class TaskContract(AsDictMixin):
         return "task-contract"
 
 
+class AllocationInfo(AsDictMixin):
+    def __init__(self, insertion_point, stn_tasks, pre_task_actions):
+        self.insertion_point = insertion_point
+        self.stn_tasks = stn_tasks
+        self.pre_task_actions = pre_task_actions
+        self._stn = None
+        self._dispatchable_graph = None
+
+    @property
+    def stn(self):
+        return self._stn
+
+    @stn.setter
+    def stn(self, stn):
+        self._stn = stn
+
+    @property
+    def dispatchable_graph(self):
+        return self._dispatchable_graph
+
+    @dispatchable_graph.setter
+    def dispatchable_graph(self, dispatchable_graph):
+        self._dispatchable_graph = dispatchable_graph
+
+    def to_dict(self):
+        dict_repr = super().to_dict()
+        stn_tasks = list()
+        pre_task_actions = list()
+        for task in self.stn_tasks:
+            stn_tasks.append(task.to_dict())
+        for action in self.pre_task_actions:
+            pre_task_actions.append(action.to_dict())
+        dict_repr.update(pre_task_actions=pre_task_actions)
+        dict_repr.update(stn_tasks=stn_tasks)
+        return dict_repr
+
+    @classmethod
+    def to_attrs(cls, dict_repr):
+        attrs = super().to_attrs(dict_repr)
+        stn_tasks = list()
+        pre_task_actions = list()
+        for task in attrs.get("stn_tasks"):
+            stn_tasks.append(STNTask.from_dict(task))
+        for action in attrs.get("pre_task_actions"):
+            pre_task_actions.append(GoTo.from_payload(action))
+        attrs.update(stn_tasks=stn_tasks)
+        attrs.update(pre_task_actions=pre_task_actions)
+        return attrs
+
+
 class TaskContractAcknowledgment(TaskContract):
-    def __init__(self, task_id, robot_id, accept=True):
+    def __init__(self, task_id, robot_id, allocation_info, accept=True):
+        self.allocation_info = allocation_info
         super().__init__(task_id, robot_id)
         self.accept = accept
+
+    @classmethod
+    def to_attrs(cls, dict_repr):
+        attrs = super().to_attrs(dict_repr)
+        attrs.update(allocation_info=AllocationInfo.from_dict(dict_repr.get("allocation_info")))
+        return attrs
 
     @property
     def meta_model(self):
         return "task-contract-acknowledgement"
-

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -64,7 +64,7 @@ class Robot:
         if self.robot_id in task.assigned_robots:
             self.logger.critical("Received task %s", task.task_id)
             task.update_status(TaskStatusConst.DISPATCHED)
-            Task.freeze_task(task.task_id)
+            task.freeze()
 
     def send_task_status(self, task):
         try:

--- a/mrs/robot_proxy.py
+++ b/mrs/robot_proxy.py
@@ -42,7 +42,7 @@ class RobotProxy:
         task = Task.from_payload(payload)
         if self.robot_id in task.assigned_robots:
             self.logger.critical("Received task %s", task.task_id)
-            Task.freeze_task(task.task_id)
+            task.freeze()
 
     def task_status_cb(self, msg):
         payload = msg['payload']

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -43,6 +43,7 @@ class Timetable(SimulatorInterface):
 
         self.stn = self.stp_solver.get_stn()
         self.dispatchable_graph = self.stp_solver.get_stn()
+        self.stn_tasks = dict()
 
     def update_ztp(self, time_):
         self.ztp.timestamp = time_
@@ -55,16 +56,8 @@ class Timetable(SimulatorInterface):
         except NoSTPSolution:
             raise NoSTPSolution()
 
-    def solve_stp(self, task, insertion_point):
-        stn_task = self.to_stn_task(task, insertion_point)
-        stn = copy.deepcopy(self.stn)
-        stn.add_task(stn_task, insertion_point)
-        try:
-            dispatchable_graph = self.stp_solver.solve(stn)
-            return stn, dispatchable_graph
-
-        except NoSTPSolution:
-            raise NoSTPSolution()
+    def insert_task(self, stn_task, insertion_point):
+        self.stn.add_task(stn_task, insertion_point)
 
     def assign_timepoint(self, assigned_time, task_id, node_type):
         stn = copy.deepcopy(self.stn)
@@ -83,6 +76,18 @@ class Timetable(SimulatorInterface):
         stn_timepoint_constraints, stn_inter_timepoint_constraints = self.get_constraints(task)
         stn_task = STNTask(task.task_id, stn_timepoint_constraints, stn_inter_timepoint_constraints)
         return stn_task
+
+    def update_stn_task(self, task, insertion_point):
+        self.update_start_constraint(task, insertion_point)
+        stn_timepoint_constraints, stn_inter_timepoint_constraints = self.get_constraints(task)
+        stn_task = STNTask(task.task_id, stn_timepoint_constraints, stn_inter_timepoint_constraints)
+        return stn_task
+
+    def get_stn_task(self, task_id):
+        return self.stn_tasks.get(task_id)
+
+    def add_stn_task(self, stn_task):
+        self.stn_tasks[stn_task.task_id] = stn_task
 
     def update_pickup_constraint(self, task, insertion_point):
         hard_pickup_constraint = task.get_timepoint_constraint("pickup")


### PR DESCRIPTION
- When inserting a new task in insertion_point, update the next task (in insertion_point+1) to reflect its new previous location. That is, update the pre-task-action in the task's plan, its start constraint and its travel_time constraint.
- msgs/dispatch_queue_update: Fix addition of edges between tasks in merged_graph .
- task: Refactor freeze method. Make it an instance method instead of a class method.
- dispatcher: Catch DoesNotExist exception triggered by timetable.get_earliest_task()
- timetable: Configure mrs.timetable.robot_id logger 